### PR TITLE
Make removeListener not crash (argument list typo)

### DIFF
--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -352,9 +352,8 @@ class UrbanAirship {
    * @param {string} eventName The event name. Either notificationResponse, pushReceived,
    * register, deepLink, or notificationOptInStatus.
    * @param {Function} listener The event listner.
-   * @return {EmitterSubscription} An emitter subscription.
    */
-  static removeListener(eventName: AirshipEventName, handler: Function) {
+  static removeListener(eventName: AirshipEventName, listener: Function) {
     var name = convertEventEnum(eventName);
     AirshipNotificationEmitter.removeListener(name, listener);
   }


### PR DESCRIPTION
`UrbanAirship.removeListener` has a typo in the argument list (`handler` instead of `listener`), which causes the method to throw when used.

This PR fixes that issue, as well as improving the documentation for the method (no `EmitterSubscription` is returned by removeListener as far as I can see).