### PR TITLE
Fixed addCustomEvent

### DIFF
--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -132,7 +132,7 @@ RCT_EXPORT_METHOD(setBackgroundLocationAllowed:(BOOL)enabled) {
 
 RCT_REMAP_METHOD(runAction,
                  name:(NSString *)name
-                 value:(NSString *)value
+                 value:(NSDictionary *)value
                  runAction_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
 


### PR DESCRIPTION
Adding customEvent with Dictionary (Object from javascript) triggers error since `runAction` expects string. 

```
[RCTConvert.m:58] JSON value '{
    ...
}' of type NSMutableDictionary cannot be converted to NSString
```

The next function in chain expects dictionary arguments and triggers another error:
```
[UAAddCustomEventAction acceptsArguments:] [Line 46] UAAddCustomEventAction requires a dictionary of event data.
```

Without this fix it is impossible to use `addCustomEvent` in ios.