### PR TITLE
[MB-2246] Adds the ability to dismiss the default message center.

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -17,14 +17,45 @@
             </intent-filter>
         </receiver>
 
-         <activity
+        <activity
             android:name="com.urbanairship.reactnative.CustomMessageCenterActivity"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:theme="@android:style/Theme.DeviceDefault.Light">
             <intent-filter>
                 <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        <activity android:name="com.urbanairship.reactnative.CustomMessageActivity"
+            android:theme="@android:style/Theme.DeviceDefault.Light">
+            <intent-filter>
+                <action android:name="com.urbanairship.VIEW_RICH_PUSH_MESSAGE" />
+                <data android:scheme="message"/>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity android:name="com.urbanairship.reactnative.CustomLandingPageActivity"
+            android:exported="false" 
+            android:theme="@style/LandingPageStyle">
+            <meta-data android:name="com.urbanairship.action.LANDING_PAGE_VIEW"
+                android:resource="@layout/ua_activity_landing_page"/>
+            <meta-data android:name="com.urbanairship.push.iam.EXCLUDE_FROM_AUTO_SHOW"
+                android:value="true"/>
+            <intent-filter>
+                <action android:name="com.urbanairship.actions.SHOW_LANDING_PAGE_INTENT_ACTION"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:scheme="message"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+
+        <activity
+            xmlns:tools="http://schemas.android.com/tools"
+            tools:node="remove"
+            android:name="com.urbanairship.actions.LandingPageActivity" />
 
     </application>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -17,6 +17,14 @@
             </intent-filter>
         </receiver>
 
+         <activity
+            android:name="com.urbanairship.reactnative.CustomMessageCenterActivity"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
     </application>
 </manifest>

--- a/android/src/main/java/com/urbanairship/reactnative/CustomLandingPageActivity.java
+++ b/android/src/main/java/com/urbanairship/reactnative/CustomLandingPageActivity.java
@@ -13,7 +13,7 @@ public class CustomLandingPageActivity extends LandingPageActivity {
     public void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
 
-        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())) {
+        if (getIntent() != null && UrbanAirshipReactModule.CLOSE_MESSAGE_CENTER.equals(getIntent().getAction())) {
             finish();
         }
 
@@ -23,7 +23,7 @@ public class CustomLandingPageActivity extends LandingPageActivity {
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
 
-        if (intent != null && "CLOSE".equals(intent.getAction())) {
+        if (intent != null && UrbanAirshipReactModule.CLOSE_MESSAGE_CENTER.equals(intent.getAction())) {
             finish();
             return;
         }

--- a/android/src/main/java/com/urbanairship/reactnative/CustomLandingPageActivity.java
+++ b/android/src/main/java/com/urbanairship/reactnative/CustomLandingPageActivity.java
@@ -1,0 +1,32 @@
+/* Copyright 2017 Urban Airship and Contributors */
+
+package com.urbanairship.reactnative;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.urbanairship.actions.LandingPageActivity;
+
+public class CustomLandingPageActivity extends LandingPageActivity {
+
+    @Override
+    public void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+
+        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())) {
+            finish();
+        }
+
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        if (intent != null && "CLOSE".equals(intent.getAction())) {
+            finish();
+            return;
+        }
+
+    }
+}

--- a/android/src/main/java/com/urbanairship/reactnative/CustomMessageActivity.java
+++ b/android/src/main/java/com/urbanairship/reactnative/CustomMessageActivity.java
@@ -12,7 +12,7 @@ public class CustomMessageActivity extends MessageActivity {
     protected void onCreate(Bundle savedInstanceState){
         super.onCreate(savedInstanceState);
 
-        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())){
+        if (getIntent() != null && UrbanAirshipReactModule.CLOSE_MESSAGE_CENTER.equals(getIntent().getAction())){
             CustomMessageActivity.this.finish();
             return;
         }
@@ -22,7 +22,7 @@ public class CustomMessageActivity extends MessageActivity {
     protected void onNewIntent(Intent intent){
         super.onNewIntent(intent);
 
-        if (intent != null && "CLOSE".equals(intent.getAction())) {
+        if (intent != null && UrbanAirshipReactModule.CLOSE_MESSAGE_CENTER.equals(intent.getAction())) {
             finish();
             return;
         }

--- a/android/src/main/java/com/urbanairship/reactnative/CustomMessageActivity.java
+++ b/android/src/main/java/com/urbanairship/reactnative/CustomMessageActivity.java
@@ -1,0 +1,31 @@
+/* Copyright 2017 Urban Airship and Contributors */
+
+package com.urbanairship.reactnative;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.urbanairship.messagecenter.MessageActivity;
+
+public class CustomMessageActivity extends MessageActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState){
+        super.onCreate(savedInstanceState);
+
+        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())){
+            CustomMessageActivity.this.finish();
+            return;
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent){
+        super.onNewIntent(intent);
+
+        if (intent != null && "CLOSE".equals(intent.getAction())) {
+            finish();
+            return;
+        }
+    }
+
+}

--- a/android/src/main/java/com/urbanairship/reactnative/CustomMessageCenterActivity.java
+++ b/android/src/main/java/com/urbanairship/reactnative/CustomMessageCenterActivity.java
@@ -11,7 +11,7 @@ public class CustomMessageCenterActivity extends MessageCenterActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())) {
+        if (getIntent() != null && UrbanAirshipReactModule.CLOSE_MESSAGE_CENTER.equals(getIntent().getAction())) {
             finish();
             return;
         }
@@ -21,7 +21,7 @@ public class CustomMessageCenterActivity extends MessageCenterActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
 
-        if (intent != null && "CLOSE".equals(intent.getAction())) {
+        if (intent != null && UrbanAirshipReactModule.CLOSE_MESSAGE_CENTER.equals(intent.getAction())) {
             finish();
             return;
         }

--- a/android/src/main/java/com/urbanairship/reactnative/CustomMessageCenterActivity.java
+++ b/android/src/main/java/com/urbanairship/reactnative/CustomMessageCenterActivity.java
@@ -1,0 +1,29 @@
+/* Copyright 2017 Urban Airship and Contributors */
+
+package com.urbanairship.reactnative;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.urbanairship.messagecenter.MessageCenterActivity;
+
+public class CustomMessageCenterActivity extends MessageCenterActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (getIntent() != null && "CLOSE".equals(getIntent().getAction())) {
+            finish();
+            return;
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        if (intent != null && "CLOSE".equals(intent.getAction())) {
+            finish();
+            return;
+        }
+    }
+}

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -72,6 +72,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     private static final String QUIET_TIME_END_MINUTE = "endMinute";
 
     static final String AUTO_LAUNCH_MESSAGE_CENTER = "com.urbanairship.auto_launch_message_center";
+    static final String CLOSE_MESSAGE_CENTER = "CLOSE";
 
     /**
      * Default constructor.
@@ -481,7 +482,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void dismissMessageCenter() {
         Intent intent = new Intent(this.getCurrentActivity(), CustomMessageCenterActivity.class)
-                .setAction("CLOSE");
+                .setAction(CLOSE_MESSAGE_CENTER);
         this.getCurrentActivity().startActivity(intent);
     }
 
@@ -528,12 +529,12 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     public void dismissMessage(boolean overlay) {
         if (overlay){
             Intent intent = new Intent(this.getCurrentActivity(), CustomLandingPageActivity.class)
-                    .setAction("CLOSE")
+                    .setAction(CLOSE_MESSAGE_CENTER)
                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             this.getCurrentActivity().startActivity(intent);
         } else {
             Intent intent = new Intent(this.getCurrentActivity(), CustomMessageActivity.class)
-                    .setAction("CLOSE")
+                    .setAction(CLOSE_MESSAGE_CENTER)
                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             this.getCurrentActivity().startActivity(intent);
         }

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -500,7 +500,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
             promise.reject("STATUS_MESSAGE_NOT_FOUND", "Message not found.");
         } else {
             if (overlay == true) {
-                Intent intent = new Intent(this.getReactApplicationContext().getCurrentActivity(), LandingPageActivity.class)
+                Intent intent = new Intent(this.getReactApplicationContext().getCurrentActivity(), CustomLandingPageActivity.class)
                         .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
                         .setPackage(this.getReactApplicationContext().getCurrentActivity().getPackageName())
                         .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
@@ -508,8 +508,34 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
 
                 this.getReactApplicationContext().startActivity(intent);
             } else {
-                UAirship.shared().getInbox().startMessageActivity(messageId);
+                Intent intent = new Intent(this.getReactApplicationContext().getCurrentActivity(), CustomMessageActivity.class)
+                        .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
+                        .setPackage(this.getReactApplicationContext().getCurrentActivity().getPackageName())
+                        .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                
+                this.getReactApplicationContext().startActivity(intent);
             }
+        }
+    }
+    
+    /**
+     * Dismisses the currently displayed inbox message.
+     *
+     * @param overlay Dismiss the message from an overlay.
+     */
+    @ReactMethod
+    public void dismissMessage(boolean overlay) {
+        if (overlay){
+            Intent intent = new Intent(this.getCurrentActivity(), CustomLandingPageActivity.class)
+                    .setAction("CLOSE")
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            this.getCurrentActivity().startActivity(intent);
+        } else {
+            Intent intent = new Intent(this.getCurrentActivity(), CustomMessageActivity.class)
+                    .setAction("CLOSE")
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            this.getCurrentActivity().startActivity(intent);
         }
     }
 

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -467,13 +467,22 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
         promise.resolve(0);
     }
 
-
     /**
      * Displays the default message center.
      */
     @ReactMethod
     public void displayMessageCenter() {
         UAirship.shared().getInbox().startInboxActivity();
+    }
+
+    /**
+     * Dismisses the default message center.
+     */
+    @ReactMethod
+    public void dismissMessageCenter() {
+        Intent intent = new Intent(this.getCurrentActivity(), CustomMessageCenterActivity.class)
+                .setAction("CLOSE");
+        this.getCurrentActivity().startActivity(intent);
     }
 
     /**

--- a/ios/UARCTModule.xcodeproj/project.pbxproj
+++ b/ios/UARCTModule.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6E42C7B01EBA953100C85B3A /* UrbanAirshipReactModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E42C7AE1EBA953100C85B3A /* UrbanAirshipReactModule.m */; };
 		6E42C8551EC0DD0900C85B3A /* UARCTEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E42C8541EC0DD0900C85B3A /* UARCTEventEmitter.m */; };
 		99B8E2CC1EC14020003FA382 /* UARCTDeepLinkAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B8E2CB1EC14020003FA382 /* UARCTDeepLinkAction.m */; };
+		F8A9D23B1F3CF8870087D225 /* UARCTMessageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A9D23A1F3CF8870087D225 /* UARCTMessageViewController.m */; };
 		F8AA2B681EEF04C0008653D8 /* UARCTMessageCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = F8AA2B671EEF04C0008653D8 /* UARCTMessageCenter.m */; };
 /* End PBXBuildFile section */
 
@@ -36,6 +37,8 @@
 		6E4D17C21EBA7FAA0032DED3 /* libUARCTModule.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUARCTModule.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B8E2CA1EC14020003FA382 /* UARCTDeepLinkAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UARCTDeepLinkAction.h; sourceTree = "<group>"; };
 		99B8E2CB1EC14020003FA382 /* UARCTDeepLinkAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UARCTDeepLinkAction.m; sourceTree = "<group>"; };
+		F8A9D23A1F3CF8870087D225 /* UARCTMessageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UARCTMessageViewController.m; path = UARCTModule/UARCTMessageViewController.m; sourceTree = "<group>"; };
+		F8A9D23C1F3CF8B90087D225 /* UARCTMessageViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UARCTMessageViewController.h; path = UARCTModule/UARCTMessageViewController.h; sourceTree = "<group>"; };
 		F8AA2B661EEF04C0008653D8 /* UARCTMessageCenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UARCTMessageCenter.h; path = UARCTModule/UARCTMessageCenter.h; sourceTree = "<group>"; };
 		F8AA2B671EEF04C0008653D8 /* UARCTMessageCenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UARCTMessageCenter.m; path = UARCTModule/UARCTMessageCenter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -64,6 +67,8 @@
 				99B8E2CB1EC14020003FA382 /* UARCTDeepLinkAction.m */,
 				6E42C7AD1EBA953100C85B3A /* UrbanAirshipReactModule.h */,
 				6E42C7AE1EBA953100C85B3A /* UrbanAirshipReactModule.m */,
+				F8A9D23A1F3CF8870087D225 /* UARCTMessageViewController.m */,
+				F8A9D23C1F3CF8B90087D225 /* UARCTMessageViewController.h */,
 			);
 			name = UARCTModule;
 			sourceTree = "<group>";
@@ -150,6 +155,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				99B8E2CC1EC14020003FA382 /* UARCTDeepLinkAction.m in Sources */,
+				F8A9D23B1F3CF8870087D225 /* UARCTMessageViewController.m in Sources */,
 				6E42C7AF1EBA953100C85B3A /* UARCTAutopilot.m in Sources */,
 				6E42C8551EC0DD0900C85B3A /* UARCTEventEmitter.m in Sources */,
 				6E42C7B01EBA953100C85B3A /* UrbanAirshipReactModule.m in Sources */,

--- a/ios/UARCTModule/UARCTMessageViewController.h
+++ b/ios/UARCTModule/UARCTMessageViewController.h
@@ -1,0 +1,7 @@
+/* Copyright 2017 Urban Airship and Contributors */
+
+#import "AirshipLib.h"
+
+@interface UARCTMessageViewController : UAMessageCenterMessageViewController
+
+@end

--- a/ios/UARCTModule/UARCTMessageViewController.m
+++ b/ios/UARCTModule/UARCTMessageViewController.m
@@ -1,0 +1,27 @@
+/* Copyright 2017 Urban Airship and Contributors */
+
+#import "UARCTMessageViewController.h"
+
+@implementation UARCTMessageViewController
+
+- (void) viewDidLoad {
+    [super viewDidLoad];
+    
+    UIBarButtonItem *done = [[UIBarButtonItem alloc]
+                             initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                             target:self
+                             action:@selector(dismissMessageViewController:)];
+    
+    self.navigationItem.rightBarButtonItem = done;
+    
+    __weak UARCTMessageViewController *weakSelf = self;
+    self.closeBlock = ^(BOOL animated) {
+        [weakSelf dismissViewControllerAnimated:animated completion:nil];
+    };
+}
+
+- (void) dismissMessageViewController:(id)sender {
+    [self dismissViewControllerAnimated:true completion:nil];
+}
+
+@end

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -6,6 +6,11 @@
 #import "UARCTDeepLinkAction.h"
 #import "UARCTAutopilot.h"
 #import "UARCTMessageCenter.h"
+#import "UARCTMessageViewController.h"
+
+@interface UrbanAirshipReactModule()
+@property (nonatomic, weak) UARCTMessageViewController *messageViewController;
+@end
 
 @implementation UrbanAirshipReactModule
 
@@ -349,8 +354,34 @@ RCT_REMAP_METHOD(displayMessage,
         if (overlay) {
             [UAOverlayViewController showMessage:message];
         } else {
-            [[UAirship defaultMessageCenter] displayMessage:message animated:true];
+            UARCTMessageViewController *mvc = [[UARCTMessageViewController alloc] initWithNibName:@"UAMessageCenterMessageViewController" bundle:[UAirship resources]];
+            [mvc loadMessage:message onlyIfChanged:true];
+            
+            UINavigationController *navController =  [[UINavigationController alloc] initWithRootViewController:mvc];
+            
+            self.messageViewController = mvc;
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navController animated:YES completion:nil];
+            });
         }
+    }
+}
+
+RCT_REMAP_METHOD(dismissMessage,
+                 overlay:(BOOL *)overlay
+                 dismissMessage_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    if (overlay) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [UAOverlayViewController closeAll:YES];
+        });
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.messageViewController dismissViewControllerAnimated:YES completion:nil];
+            self.messageViewController = nil;
+        });
     }
 }
 

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -325,6 +325,12 @@ RCT_EXPORT_METHOD(displayMessageCenter) {
     });
 }
 
+RCT_EXPORT_METHOD(dismissMessageCenter) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UAirship defaultMessageCenter] dismiss];
+    });
+}
+
 RCT_REMAP_METHOD(displayMessage,
                  messageId:(NSString *)messageId
                  overlay:(BOOL *)overlay

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -465,6 +465,15 @@ class UrbanAirship {
   }
 
   /**
+   * Dismisses the currently displayed inbox message. 
+   *
+   * @param {boolean} [overlay=false] Dismisses the message in an overlay.
+   */
+  static dismissMessage(overlay: ?boolean) {
+    UrbanAirshipModule.dismissMessage(overlay);
+  }
+
+  /**
    * Retrieves the current inbox messages. Each message will have the following properties:
    * "id": string - The messages ID. Needed to display, mark as read, or delete the message.
    * "title": string - The message title.

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -447,6 +447,13 @@ class UrbanAirship {
   }
 
   /**
+   * Dismisses the default message center.
+   */
+  static dismissMessageCenter() {
+    UrbanAirshipModule.dismissMessageCenter();
+  }
+
+  /**
    * Displays an inbox message.
    *
    * @param {string} messageId The id of the message to be displayed.

--- a/sample/AirshipSample/app.js
+++ b/sample/AirshipSample/app.js
@@ -25,13 +25,18 @@ import {
   TouchableOpacity,
   TextInput,
   Alert,
+  ScrollView,
+  Dimensions,
 } from 'react-native';
 
 const styles = StyleSheet.create({
-  centeredContainer: {
+  backgroundContainer: {
     flex: 1,
     flexDirection:'column',
-    justifyContent: 'center',
+    backgroundColor: '#E0A500',
+  },
+  contentContainer: {
+    paddingVertical: 20,
     alignItems: 'center',
     backgroundColor: '#E0A500',
   },
@@ -143,6 +148,7 @@ export default class AirshipSample extends Component {
     this.handleNamedUserSet = this.handleNamedUserSet.bind(this);
     this.handleUpdateNamedUserText = this.handleUpdateNamedUserText.bind(this);
     this.handleRenderNamedUser = this.handleRenderNamedUser.bind(this);
+    this.handleMessageCenterDisplay = this.handleMessageCenterDisplay.bind(this);
 
     this.handleUpdateTagsList();
     this.handleUpdateNamedUser();
@@ -213,6 +219,10 @@ export default class AirshipSample extends Component {
     this.setState({tagText:text})
   }
 
+  handleMessageCenterDisplay() {
+    UrbanAirship.displayMessageCenter()
+  }
+
   componentWillMount() {
     UrbanAirship.getChannelId().then((channelId) => {
       this.setState({channelId:channelId})
@@ -260,42 +270,50 @@ export default class AirshipSample extends Component {
     }
 
     return (
-      <View style={styles.centeredContainer}>
-        <Image
-          style={{width: 300, height: 38, marginTop:50}}
-          source={require('./img/urban-airship-sidebyside.png')}
-        />
-        <View style={{height:75}}>
-        </View>
-        <EnablePushCell
-          notificationsEnabled={this.state.notificationsEnabled}
-          handleNotificationsEnabled={this.handleNotificationsEnabled}
-        />
-        <View>
-          {channelcell}
-        </View>
-        <NamedUserManagerCell
-          namedUserText={this.state.namedUserText}
-          handleNamedUserSet={this.handleNamedUserSet}
-          handleUpdateNamedUserText={this.handleUpdateNamedUserText}
-          handleRenderNamedUser={this.handleRenderNamedUser}
-        />
-        <TagsManagerCell
-          tagText={this.state.tagText}
-          tagsDS={this.state.tagsDS}
-          handleTagAdd={this.handleTagAdd}
-          handleTagRemove={this.handleTagRemove}
-          handleUpdateTagText={this.handleUpdateTagText}
-        />
-        <EnableLocationCell
-          locationEnabled={this.state.locationEnabled}
-          handleLocationEnabled={this.handleLocationEnabled}
-        />
-        <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
-        </Text>
-      </View>
+      <View style={styles.backgroundContainer}>
+        <ScrollView contentContainerStyle={styles.contentContainer}>
+          <Image
+            style={{width: 300, height: 38, marginTop:50, alignItems:'center'}}
+            source={require('./img/urban-airship-sidebyside.png')}
+          />
+          <View style={{height:75}}>
+            </View>
+              <EnablePushCell
+                notificationsEnabled={this.state.notificationsEnabled}
+                handleNotificationsEnabled={this.handleNotificationsEnabled}
+              />
+            <View>
+              {channelcell}
+          </View>
+          <NamedUserManagerCell
+            namedUserText={this.state.namedUserText}
+            handleNamedUserSet={this.handleNamedUserSet}
+            handleUpdateNamedUserText={this.handleUpdateNamedUserText}
+            handleRenderNamedUser={this.handleRenderNamedUser}
+          />
+          <TagsManagerCell
+            tagText={this.state.tagText}
+            tagsDS={this.state.tagsDS}
+            handleTagAdd={this.handleTagAdd}
+            handleTagRemove={this.handleTagRemove}
+            handleUpdateTagText={this.handleUpdateTagText}
+          />
+          <EnableLocationCell
+            locationEnabled={this.state.locationEnabled}
+            handleLocationEnabled={this.handleLocationEnabled}
+          />
+          <Button
+             color='#0d6a83'
+             onPress={() => this.handleMessageCenterDisplay()}
+             title="Message Center"
+          />
+          <Text style={styles.instructions}>
+            Press Cmd+R to reload,{'\n'}
+            Cmd+D or shake for dev menu
+          </Text>
+        </ScrollView>
+    </View>
+
     );
   }
 }


### PR DESCRIPTION
Adds the ability to dismiss showing message center and message center messages. Dismissing message center is useful for apps that use the displayMessageCenter, while individual message dismissal is used for when an app displays their own message displaying.

On Android, its hard to access the activity stack in a clean non terrible way. Instead we will send an intent to the activities to close themselves. If the activity is currently running it will  receive the new intent through `onNewIntent`, if its not running it will just close itself immediately before its displayed to the user.