### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 1.2.0 - August 18, 2017
+=============================
+- Added support for dismissing messages from outside the Message Center
+- Added support for Carthage
+- Updated Urban Airship Android SDK to 8.8.2
+- Fixed opt-in events to be more responsive to authorization status changes
+
 Version 1.1.0 - June 21, 2017
 =============================
 - Added Message Center support

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     compile 'com.facebook.react:react-native:[0.40,)'
     compile 'com.google.android.gms:play-services-gcm:[11.0.1,)'
 
-    compile 'com.urbanairship.android:urbanairship-sdk:8.6.0'
+    compile 'com.urbanairship.android:urbanairship-sdk:8.8.2'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/sample/AirshipSample/package.json
+++ b/sample/AirshipSample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AirshipSample",
-  "version": "1.0.3",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"


### PR DESCRIPTION
This is the react native release for version 1.2.0

It does the following things:
-Updates the Android SDK (the newest iOS SDK is auto selected by cocoapods)
-Add message center functionality for dismissing messages from outside the message center
-More responsive opt-in events
