### PR TITLE
Fix Android package class to support RN 0.47

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPackage.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPackage.java
@@ -22,7 +22,7 @@ public class ReactAirshipPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new UrbanAirshipReactModule(reactContext));
     }
 
-    @Override
+    // deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
ReactPackage.java does not have createJSModules anymore. Comment override annotation to support both RN >= 0.47 and RN < 0.47.