### PR TITLE
CE-3644: Fix quiet time methods in UrbanAirship.js

### DIFF
--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -401,7 +401,7 @@ class UrbanAirship {
    * @param {boolean} enabled true to enable quiet time, false to disable.
    */
   static setQuietTimeEnabled(enabled: boolean) {
-    UrbanAirshipModule.setUserNotificationsEnabled(enabled);
+    UrbanAirshipModule.setQuietTimeEnabled(enabled);
   }
 
   /**
@@ -410,7 +410,7 @@ class UrbanAirship {
    * @return {Promise.<boolean>} A promise with the result.
    */
   static isQuietTimeEnabled(): Promise<boolean> {
-    return UrbanAirshipModule.isUserNotificationsEnabled();
+    return UrbanAirshipModule.isQuietTimeEnabled();
   }
 
   /**


### PR DESCRIPTION
This PR fixes how setQuietTimeEnabled() and isQuietTimeEnabled() are set. Previously, these methods modified the values of user notifications (i.e. if quiet time was set to false then user notifications would get set to false):

```
/**
   * Enables or disables quiet time.
   *
   * @param {boolean} enabled true to enable quiet time, false to disable.
   */
  static setQuietTimeEnabled(enabled: boolean) {
    UrbanAirshipModule.setUserNotificationsEnabled(enabled);
  }

  /**
   * Checks if quietTime is enabled or not.
   *
   * @return {Promise.<boolean>} A promise with the result.
   */
  static isQuietTimeEnabled(): Promise<boolean> {
    return UrbanAirshipModule.isUserNotificationsEnabled();
  }
```

Now these methods only modify the value of quiet time. 
