### PR TITLE
Add notification management support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 1.3.0 - November 15, 2017
+=================================
+- Added APIs to manage active notifications.
+
 Version 1.2.3 - October 30, 2017
 ================================
 - Changed Android Message Center title to be "Message Center" instead of the app name

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAirshipReceiver.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAirshipReceiver.java
@@ -37,9 +37,18 @@ public class ReactAirshipReceiver extends AirshipReceiver {
         UrbanAirshipReactModule.checkOptIn(context);
     }
 
+
     @Override
     protected void onPushReceived(@NonNull Context context, @NonNull PushMessage message, boolean notificationPosted) {
-        Event event = new PushReceivedEvent(message);
+        if (!notificationPosted) {
+            Event event = new PushReceivedEvent(message);
+            EventEmitter.shared().sendEvent(context, event);
+        }
+    }
+
+    @Override
+    protected void onNotificationPosted(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
+        Event event = new PushReceivedEvent(notificationInfo);
         EventEmitter.shared().sendEvent(context, event);
     }
 

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
@@ -4,6 +4,7 @@ package com.urbanairship.reactnative;
 
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
 
 import com.urbanairship.Autopilot;
 import com.urbanairship.UAirship;
@@ -14,9 +15,12 @@ import com.urbanairship.actions.ActionResult;
 import com.urbanairship.actions.DeepLinkAction;
 import com.urbanairship.actions.OpenRichPushInboxAction;
 import com.urbanairship.actions.OverlayRichPushMessageAction;
+import com.urbanairship.push.PushManager;
 import com.urbanairship.reactnative.events.DeepLinkEvent;
 import com.urbanairship.reactnative.events.InboxUpdatedEvent;
 import com.urbanairship.richpush.RichPushInbox;
+import com.urbanairship.push.notifications.DefaultNotificationFactory;
+import com.urbanairship.push.PushMessage;
 
 import static com.urbanairship.reactnative.UrbanAirshipReactModule.AUTO_LAUNCH_MESSAGE_CENTER;
 
@@ -78,6 +82,24 @@ public class ReactAutopilot extends Autopilot {
                         return true;
                     }
                 });
+
+
+        DefaultNotificationFactory notificationFactory = new DefaultNotificationFactory(UAirship.getApplicationContext()) {
+            @Override
+            public NotificationCompat.Builder extendBuilder(@NonNull NotificationCompat.Builder builder, @NonNull PushMessage message, int notificationId) {
+                builder.getExtras().putBundle("push_message", message.getPushBundle());
+                return builder;
+            }
+        };
+
+        if (airship.getAirshipConfigOptions().notificationIcon != 0) {
+            notificationFactory.setSmallIconId(airship.getAirshipConfigOptions().notificationIcon);
+        }
+
+        notificationFactory.setColor(airship.getAirshipConfigOptions().notificationAccentColor);
+        notificationFactory.setNotificationChannel(airship.getAirshipConfigOptions().notificationChannel);
+
+        airship.getPushManager().setNotificationFactory(notificationFactory);
     }
 
 }

--- a/android/src/main/java/com/urbanairship/reactnative/events/NotificationResponseEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/NotificationResponseEvent.java
@@ -22,7 +22,6 @@ public class NotificationResponseEvent implements Event {
     private static final String RESPONSE_FOREGROUND = "isForeground";
     private static final String RESPONSE_NOTIFICATION = "notification";
 
-
     private final AirshipReceiver.NotificationInfo notificationInfo;
     private final AirshipReceiver.ActionButtonInfo actionButtonInfo;
 
@@ -56,8 +55,7 @@ public class NotificationResponseEvent implements Event {
     @Override
     public WritableMap getBody() {
         WritableMap map = Arguments.createMap();
-        map.putMap(RESPONSE_NOTIFICATION, new PushReceivedEvent(notificationInfo.getMessage()).getBody());
-
+        map.putMap(RESPONSE_NOTIFICATION, new PushReceivedEvent(notificationInfo).getBody());
 
         if (actionButtonInfo != null) {
             map.putString(RESPONSE_ACTION_ID, actionButtonInfo.getButtonId());
@@ -65,6 +63,7 @@ public class NotificationResponseEvent implements Event {
         } else {
             map.putBoolean(RESPONSE_FOREGROUND, true);
         }
+
 
         return map;
     }

--- a/android/src/main/java/com/urbanairship/reactnative/events/PushReceivedEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/PushReceivedEvent.java
@@ -2,13 +2,17 @@
 
 package com.urbanairship.reactnative.events;
 
+import android.app.Notification;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.urbanairship.push.PushMessage;
+import com.urbanairship.AirshipReceiver;
 import com.urbanairship.reactnative.Event;
+import com.urbanairship.util.UAStringUtil;
+
 
 
 /**
@@ -20,8 +24,11 @@ public class PushReceivedEvent implements Event {
     private static final String PUSH_ALERT = "alert";
     private static final String PUSH_TITLE = "title";
     private static final String PUSH_EXTRAS = "extras";
+    private static final String NOTIFICATION_ID = "notificationId";
 
     private final PushMessage message;
+    private Integer notificationId;
+    private String notificationTag;
 
     /**
      * Default constructor.
@@ -31,6 +38,30 @@ public class PushReceivedEvent implements Event {
     public PushReceivedEvent(@NonNull PushMessage message) {
         this.message = message;
     }
+
+    /**
+     * Default constructor.
+     *
+     * @param notificationInfo The posted notification info.
+     */
+    public PushReceivedEvent(@NonNull AirshipReceiver.NotificationInfo notificationInfo) {
+        this.message = notificationInfo.getMessage();
+        this.notificationId = notificationInfo.getNotificationId();
+        this.notificationTag = notificationInfo.getNotificationTag();
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param message The push message.
+     */
+    public PushReceivedEvent(@NonNull PushMessage message, int notificationId, String notificationTag) {
+        this.message = message;
+        this.notificationId = notificationId;
+        this.notificationTag = notificationTag;
+    }
+
+
 
     @NonNull
     @Override
@@ -51,6 +82,10 @@ public class PushReceivedEvent implements Event {
             map.putString(PUSH_TITLE, message.getTitle());
         }
 
+        if (notificationId != null) {
+            map.putString(NOTIFICATION_ID, getNotificationdId(notificationId, notificationTag));
+        }
+
         Bundle bundle = new Bundle(message.getPushBundle());
         bundle.remove("android.support.content.wakelockid");
         map.putMap(PUSH_EXTRAS, Arguments.fromBundle(bundle));
@@ -61,5 +96,15 @@ public class PushReceivedEvent implements Event {
     @Override
     public boolean isCritical() {
         return false;
+    }
+
+
+    static String getNotificationdId(int notificationId, String notificationTag) {
+        String id = String.valueOf(notificationId);
+        if (!UAStringUtil.isEmpty(notificationTag)) {
+            id += ":" + notificationTag;
+        }
+
+        return id;
     }
 }

--- a/ios/UARCTModule/UARCTEventEmitter.h
+++ b/ios/UARCTModule/UARCTEventEmitter.h
@@ -48,4 +48,12 @@ extern NSString *const UARCTNotificationPresentationSoundKey;
  */
 - (void)inboxUpdated;
 
+/**
+ * Creates a push map for a given notification content.
+ * @param content The notification content.
+ * @return Push map.
+ */
++ (NSMutableDictionary *)eventBodyForNotificationContent:(UANotificationContent *)content;
+
+
 @end

--- a/ios/UARCTModule/UARCTEventEmitter.m
+++ b/ios/UARCTModule/UARCTEventEmitter.m
@@ -89,14 +89,14 @@ static UARCTEventEmitter *sharedEventEmitter_;
 -(void)receivedForegroundNotification:(UANotificationContent *)notificationContent
                     completionHandler:(void (^)(void))completionHandler {
 
-    [self sendEventWithName:UARCTPushReceivedEventName body:[self eventBodyForNotificationContent:notificationContent]];
+    [self sendEventWithName:UARCTPushReceivedEventName body:[UARCTEventEmitter eventBodyForNotificationContent:notificationContent]];
     completionHandler();
 }
 
 -(void)receivedBackgroundNotification:(UANotificationContent *)notificationContent
                     completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
-    [self sendEventWithName:UARCTPushReceivedEventName body:[self eventBodyForNotificationContent:notificationContent]];
+    [self sendEventWithName:UARCTPushReceivedEventName body:[UARCTEventEmitter eventBodyForNotificationContent:notificationContent]];
     completionHandler(UIBackgroundFetchResultNoData);
 }
 
@@ -176,7 +176,7 @@ static UARCTEventEmitter *sharedEventEmitter_;
 
 - (NSMutableDictionary *)eventBodyForNotificationResponse:(UANotificationResponse *)notificationResponse {
     NSMutableDictionary *body = [NSMutableDictionary dictionary];
-    [body setValue:[self eventBodyForNotificationContent:notificationResponse.notificationContent] forKey:@"notification"];
+    [body setValue:[UARCTEventEmitter eventBodyForNotificationContent:notificationResponse.notificationContent] forKey:@"notification"];
 
     if ([notificationResponse.actionIdentifier isEqualToString:UANotificationDefaultActionIdentifier]) {
         [body setValue:@(YES) forKey:@"isForeground"];
@@ -192,7 +192,7 @@ static UARCTEventEmitter *sharedEventEmitter_;
     return body;
 }
 
-- (NSMutableDictionary *)eventBodyForNotificationContent:(UANotificationContent *)content {
++ (NSMutableDictionary *)eventBodyForNotificationContent:(UANotificationContent *)content {
     NSMutableDictionary *pushBody = [NSMutableDictionary dictionary];
     [pushBody setValue:content.alertBody forKey:@"alert"];
     [pushBody setValue:content.alertTitle forKey:@"title"];
@@ -210,6 +210,11 @@ static UARCTEventEmitter *sharedEventEmitter_;
 
     if (extras.count) {
         [pushBody setValue:extras forKey:@"extras"];
+    }
+
+    if (@available(iOS 10.0, *)) {
+        NSString *identifier = content.notification.request.identifier;
+        [pushBody setValue:identifier forKey:@"notificationId"];
     }
 
     return pushBody;

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -15,6 +15,9 @@
 
 NSString * const UARCTErrorDomain = @"com.urbanairship.react";
 
+NSString *const UARCTStatusUnavailable = @"UNAVAILABLE";
+
+
 #pragma mark -
 #pragma mark Module setup
 
@@ -62,8 +65,8 @@ RCT_REMAP_METHOD(isUserNotificationsOptedIn,
 }
 
 RCT_EXPORT_METHOD(setNamedUser:(NSString *)namedUser) {
-  namedUser = [namedUser stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-  [UAirship namedUser].identifier = namedUser.length ? namedUser : nil;
+    namedUser = [namedUser stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    [UAirship namedUser].identifier = namedUser.length ? namedUser : nil;
 }
 
 RCT_REMAP_METHOD(getNamedUser,
@@ -340,14 +343,14 @@ RCT_REMAP_METHOD(displayMessage,
                  overlay:(BOOL *)overlay
                  displayMessage_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     UAInboxMessage *message = [[UAirship inbox].messageList messageForID:messageId];
-    
+
     if (!message) {
         NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
                                               code:UARCTErrorCodeMessageNotFound
                                           userInfo:@{NSLocalizedDescriptionKey:UARCTErrorDescriptionMessageNotFound}];
-        
+
         reject(UARCTStatusMessageNotFound, UARCTErrorDescriptionMessageNotFound, error);
     } else {
         if (overlay) {
@@ -355,11 +358,11 @@ RCT_REMAP_METHOD(displayMessage,
         } else {
             UARCTMessageViewController *mvc = [[UARCTMessageViewController alloc] initWithNibName:@"UAMessageCenterMessageViewController" bundle:[UAirship resources]];
             [mvc loadMessage:message onlyIfChanged:true];
-            
+
             UINavigationController *navController =  [[UINavigationController alloc] initWithRootViewController:mvc];
-            
+
             self.messageViewController = mvc;
-            
+
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navController animated:YES completion:nil];
             });
@@ -371,7 +374,7 @@ RCT_REMAP_METHOD(dismissMessage,
                  overlay:(BOOL *)overlay
                  dismissMessage_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (overlay) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [UAOverlayViewController closeAll:YES];
@@ -385,16 +388,16 @@ RCT_REMAP_METHOD(dismissMessage,
 }
 
 RCT_REMAP_METHOD(getInboxMessages,
-                  getInboxMessages_resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    
+                 getInboxMessages_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+
     NSMutableArray *messages = [NSMutableArray array];
     for (UAInboxMessage *message in [UAirship inbox].messageList.messages) {
-        
+
         NSDictionary *icons = [message.rawMessageObject objectForKey:@"icons"];
         NSString *iconUrl = [icons objectForKey:@"list_icon"];
         NSNumber *sentDate = @([message.messageSent timeIntervalSince1970] * 1000);
-    
+
         NSMutableDictionary *messageInfo = [NSMutableDictionary dictionary];
         [messageInfo setValue:message.title forKey:@"title"];
         [messageInfo setValue:message.messageID forKey:@"id"];
@@ -403,7 +406,7 @@ RCT_REMAP_METHOD(getInboxMessages,
         [messageInfo setValue:message.unread ? @NO : @YES  forKey:@"isRead"];
         [messageInfo setValue:message.extra forKey:@"extras"];
         [messageInfo setObject:message.deleted ? @NO : @YES forKey:@"isDeleted"];
-        
+
         [messages addObject:messageInfo];
     }
 
@@ -414,14 +417,14 @@ RCT_REMAP_METHOD(deleteInboxMessage,
                  messageId:(NSString *)messageId
                  deleteMessage_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     UAInboxMessage *message = [[UAirship inbox].messageList messageForID:messageId];
-    
+
     if (!message) {
         NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
                                               code:UARCTErrorCodeMessageNotFound
                                           userInfo:@{NSLocalizedDescriptionKey:UARCTErrorDescriptionMessageNotFound}];
-        
+
         reject(UARCTStatusMessageNotFound, UARCTErrorDescriptionMessageNotFound, error);
     } else {
         [[UAirship inbox].messageList markMessagesDeleted:@[message] completionHandler:^(){
@@ -434,14 +437,14 @@ RCT_REMAP_METHOD(markInboxMessageRead,
                  messageId:(NSString *)messageId
                  markMessageRead_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     UAInboxMessage *message = [[UAirship inbox].messageList messageForID:messageId];
-    
+
     if (!message) {
         NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
                                               code:UARCTErrorCodeMessageNotFound
                                           userInfo:@{NSLocalizedDescriptionKey:UARCTErrorDescriptionMessageNotFound}];
-        
+
         reject(UARCTStatusMessageNotFound, UARCTErrorDescriptionMessageNotFound, error);
     } else {
         [[UAirship inbox].messageList markMessagesRead:@[message] completionHandler:^(){
@@ -453,7 +456,7 @@ RCT_REMAP_METHOD(markInboxMessageRead,
 RCT_REMAP_METHOD(refreshInbox,
                  refreshInbox_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     [[UAirship inbox].messageList retrieveMessageListWithSuccessBlock:^(){
         resolve(@YES);
     } withFailureBlock:^(){
@@ -469,4 +472,42 @@ RCT_EXPORT_METHOD(setAutoLaunchDefaultMessageCenter:(BOOL)enabled) {
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
+RCT_EXPORT_METHOD(clearNotifications) {
+    if (@available(iOS 10.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] removeAllDeliveredNotifications];
+    }
+}
+
+RCT_EXPORT_METHOD(clearNotification:(NSString *)identifier) {
+    if (@available(iOS 10.0, *)) {
+        if (identifier) {
+            [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:@[identifier]];
+        }
+    }
+}
+
+RCT_REMAP_METHOD(getActiveNotifications,
+                 getNotifications_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+
+    if (@available(iOS 10.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
+
+            NSMutableArray *result = [NSMutableArray array];
+            for(UNNotification *unnotification in notifications) {
+                UANotificationContent *content = [UANotificationContent notificationWithUNNotification:unnotification];
+                [result addObject:[UARCTEventEmitter eventBodyForNotificationContent:content]];
+            }
+
+            resolve(result);
+        }];
+    } else {
+        NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
+                                              code:0
+                                          userInfo:@{NSLocalizedDescriptionKey:@"Only available on iOS 10+"}];
+
+        reject(UARCTStatusUnavailable, @"Only available on iOS 10+", error);
+    }
+}
 @end
+

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -58,6 +58,7 @@ export type UAEventName = $Enum<{
  * @param {object} notification The notification.
  * @param {string} notification.alert The notification alert.
  * @param {string} notification.title The notification title.
+ * @param {string} notification.notificationId The notification ID.
  * @param {object} notification.extras Any push extras.
  * @param {string=} actionId The ID of the notification action button if available.
  * @param {boolean} isForeground Will always be true if the user taps the main notification. Otherwise its defined by the notificaiton action button.
@@ -70,7 +71,9 @@ export type UAEventName = $Enum<{
  * @type {object}
  * @param {string} alert The notification alert.
  * @param {string} title The notification title.
+ * @param {string} notification.notificationId The notification ID.
  * @param {object} extras Any push extras.
+
  */
 
 /**
@@ -465,7 +468,7 @@ class UrbanAirship {
   }
 
   /**
-   * Dismisses the currently displayed inbox message. 
+   * Dismisses the currently displayed inbox message.
    *
    * @param {boolean} [overlay=false] Dismisses the message in an overlay.
    */
@@ -528,6 +531,39 @@ class UrbanAirship {
    */
   static setAutoLaunchDefaultMessageCenter(enabled: boolean) {
     UrbanAirshipModule.setAutoLaunchDefaultMessageCenter(enabled);
+  }
+
+  /**
+   * Gets all the active notifications for the application.
+   * Supported on Android Marshmallow (23)+ and iOS 10+.
+   *
+   * @return {Promise.<Array>} A promise with the result.
+   */
+  static getActiveNotifications(): Promise<Array> {
+    return UrbanAirshipModule.getActiveNotifications();
+  }
+
+  /**
+   * Clears all notificaitons for the application.
+   * Supported on Android and iOS 10+. For older iOS devices, you can set
+   * the badge number to 0 to clear notificaitons.
+   *
+   * @param {boolean} [enabled=true] true to automatically launch the default message center, false to disable.
+   */
+  static clearNotifications() {
+    UrbanAirshipModule.clearNotifications();
+  }
+
+  /**
+   * Clears a specific notification.
+   * Supported on Android and iOS 10+.
+   *
+   * @param {string} identifier The notification identifier. The identifier will
+   * available in the pushReceived event and in the active notificaiton response
+   * under the "notificationId" field.
+   */
+  static clearNotification(identifier: string) {
+    UrbanAirshipModule.clearNotification(identifier)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/sample/AirshipSample/android/app/build.gradle
+++ b/sample/AirshipSample/android/app/build.gradle
@@ -84,7 +84,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.airshipsample"

--- a/sample/AirshipSample/android/build.gradle
+++ b/sample/AirshipSample/android/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -20,5 +21,6 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        google()
     }
 }

--- a/sample/AirshipSample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/AirshipSample/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 02 13:51:11 PDT 2017
+#Fri Nov 10 09:42:57 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Adds support to clear and get active notifications. Adds 3 methods:

- getActiveNotifications: Returns the current notifications in the notification center
- clearNotifications: Clears all notifications for the app.
- clearNotification(identifier): Clears a specific notification.

Android notification Ids are a unique combination of a tag and int id. To normalize the API between iOS and Android, Android will expose the notification Id as "id:tag" and then parse it to do the actual clear.



https://github.com/urbanairship/react-native-module/issues/54
