### PR TITLE
Fix Android event emission

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -36,11 +36,12 @@ class EventEmitter {
     }
 
     /**
-     * Adds an event listener.
+     * Increases the event listener count.
+     * Invokes any pending events.
      *
      * @param context The application context.
      */
-    void addListener(Context context) {
+    void increaseListenerCount(Context context) {
         listenerCount++;
         if (listenerCount > 0 && pendingEvents.size() > 0) {
             for (Event event : pendingEvents) {
@@ -51,9 +52,9 @@ class EventEmitter {
     }
 
     /**
-     * Removes an event listener.
+     * Decreases the event listener count.
      */
-    void removeListener() {
+    void decreaseListenerCount() {
         listenerCount = Math.max(listenerCount - 1, 0);
     }
 

--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -37,7 +37,7 @@ class EventEmitter {
 
     /**
      * Increases the event listener count.
-     * Invokes any pending events.
+     * Sends any pending events.
      *
      * @param context The application context.
      */

--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -13,6 +13,9 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.urbanairship.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Emits events to listeners in the JS layer.
  */
@@ -20,6 +23,8 @@ class EventEmitter {
 
     private static EventEmitter sharedInstance = new EventEmitter();
     private ReactInstanceManager reactInstanceManager;
+    private List<Event> pendingEvents = new ArrayList<>();
+    private int listenerCount = 0;
 
     /**
      * Returns the shared {@link EventEmitter} instance.
@@ -28,6 +33,28 @@ class EventEmitter {
      */
     static EventEmitter shared() {
         return sharedInstance;
+    }
+
+    /**
+     * Adds an event listener.
+     *
+     * @param context The application context.
+     */
+    void addListener(Context context) {
+        listenerCount++;
+        if (listenerCount > 0 && pendingEvents.size() > 0) {
+            for (Event event : pendingEvents) {
+                sendEvent(context, event);
+            }
+            pendingEvents.clear();
+        }
+    }
+
+    /**
+     * Removes an event listener.
+     */
+    void removeListener() {
+        listenerCount = Math.max(listenerCount - 1, 0);
     }
 
     /**
@@ -47,6 +74,11 @@ class EventEmitter {
                 }
             });
 
+            return;
+        }
+
+        if (listenerCount == 0) {
+            pendingEvents.add(event);
             return;
         }
 

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -710,6 +710,22 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * Adds an event listener.
+     */
+    @ReactMethod
+    public void addListener() {
+        EventEmitter.shared().addListener(UAirship.getApplicationContext());
+    }
+
+    /**
+     * Removes an event listener.
+     */
+    @ReactMethod
+    public void removeListener() {
+        EventEmitter.shared().removeListener();
+    }
+
+    /**
      * Helper method to apply tag group changes.
      *
      * @param editor     The tag group editor.

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -710,19 +710,19 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Adds an event listener.
+     * Increases the event listener count.
      */
     @ReactMethod
-    public void addListener() {
-        EventEmitter.shared().addListener(UAirship.getApplicationContext());
+    public void increaseListenerCount() {
+        EventEmitter.shared().increaseListenerCount(UAirship.getApplicationContext());
     }
 
     /**
-     * Removes an event listener.
+     * Decreases the event listener count.
      */
     @ReactMethod
-    public void removeListener() {
-        EventEmitter.shared().removeListener();
+    public void decreaseListenerCount() {
+        EventEmitter.shared().decreaseListenerCount();
     }
 
     /**

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -357,7 +357,7 @@ class UrbanAirship {
    */
   static addListener(eventName: UAEventName, listener: Function): EmitterSubscription {
     if (Platform.OS === 'android') {
-      UrbanAirshipModule.addListener();
+      UrbanAirshipModule.increaseListenerCount();
     }
     var name = convertEventEnum(eventName);
     return AirshipNotificationEmitter.addListener(name, listener);
@@ -372,7 +372,7 @@ class UrbanAirship {
    */
   static removeListener(eventName: AirshipEventName, listener: Function) {
     if (Platform.OS === 'android') {
-      UrbanAirshipModule.removeListener();
+      UrbanAirshipModule.decreaseListenerCount();
     }
     var name = convertEventEnum(eventName);
     AirshipNotificationEmitter.removeListener(name, listener);

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -352,10 +352,13 @@ class UrbanAirship {
    *
    * @param {string} eventName The event name. Either notificationResponse, pushReceived,
    * register, deepLink, or notificationOptInStatus.
-   * @param {Function} listener The event listner.
+   * @param {Function} listener The event listener.
    * @return {EmitterSubscription} An emitter subscription.
    */
   static addListener(eventName: UAEventName, listener: Function): EmitterSubscription {
+    if (Platform.OS === 'android') {
+      UrbanAirshipModule.addListener();
+    }
     var name = convertEventEnum(eventName);
     return AirshipNotificationEmitter.addListener(name, listener);
   }
@@ -365,9 +368,12 @@ class UrbanAirship {
    *
    * @param {string} eventName The event name. Either notificationResponse, pushReceived,
    * register, deepLink, or notificationOptInStatus.
-   * @param {Function} listener The event listner.
+   * @param {Function} listener The event listener.
    */
   static removeListener(eventName: AirshipEventName, listener: Function) {
+    if (Platform.OS === 'android') {
+      UrbanAirshipModule.removeListener();
+    }
     var name = convertEventEnum(eventName);
     AirshipNotificationEmitter.removeListener(name, listener);
   }


### PR DESCRIPTION
Fixes #58.

I was aiming to make it as similar as possible to the current iOS implementation.

Because of https://github.com/facebook/react-native/blob/a93b7a2da0849f15708afef1ff99022d8cc55b14/Libraries/EventEmitter/NativeEventEmitter.js#L37 I had to add two additional `@ReactMethod`s:
- `increaseListenerCount()`
- `decreaseListenerCount()`