### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 1.3.1 - December 22, 2017
+=================================
+- Fixed bug in iOS that caused message center to launch with auto launch disabled.
+
 Version 1.3.0 - November 15, 2017
 =================================
 - Added APIs to manage active notifications.

--- a/ios/UARCTModule/UARCTMessageCenter.m
+++ b/ios/UARCTModule/UARCTMessageCenter.m
@@ -26,13 +26,13 @@ int const UARCTErrorCodeInboxRefreshFailed = 1;
 #pragma mark UAInboxDelegate
 
 - (void)showInboxMessage:(UAInboxMessage *)message {
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTAutoLaunchMessageCenterKey]) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:UARCTAutoLaunchMessageCenterKey]) {
         [[UAirship defaultMessageCenter] displayMessage:message];
     }
 }
 
 - (void)showInbox {
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTAutoLaunchMessageCenterKey]) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:UARCTAutoLaunchMessageCenterKey]) {
         [[UAirship defaultMessageCenter] display];
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/sample/AirshipSample/package.json
+++ b/sample/AirshipSample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AirshipSample",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"


### PR DESCRIPTION
objectForKey was being used instead of boolForKey when checking the auto launch flag. Manually tested.