### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 1.4.1 - February 12, 2018
+=================================
+- Updated Urban Airship iOS SDK to 9.0.2
+- Fixed compatibility issues with iOS SDK 9.0
+
 Version 1.4.0 - February 7, 2018
 =================================
 - Updated Urban Airship iOS SDK to 9.0.1

--- a/ios/UARCTModule/UARCTAutopilot.m
+++ b/ios/UARCTModule/UARCTAutopilot.m
@@ -1,13 +1,12 @@
 /* Copyright 2017 Urban Airship and Contributors */
 
-
 #import "UARCTAutopilot.h"
 #import "UARCTEventEmitter.h"
 #import "UARCTDeepLinkAction.h"
 #import "UARCTMessageCenter.h"
 
 NSString *const UARCTPresentationOptionsStorageKey = @"com.urbanairship.presentation_options";
-NSString *const UARCTAirshipKitRecommendedVersion = @"9.0.1";
+NSString *const UARCTAirshipKitRecommendedVersion = @"9.0.2";
 
 @implementation UARCTAutopilot
 
@@ -39,7 +38,7 @@ NSString *const UARCTAirshipKitRecommendedVersion = @"9.0.1";
     if (presentationOptions) {
         [[UAirship push] setDefaultPresentationOptions:presentationOptions];
     }
-    
+
     if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTAutoLaunchMessageCenterKey] == nil) {
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:UARCTAutoLaunchMessageCenterKey];
         [[NSUserDefaults standardUserDefaults] synchronize];

--- a/ios/UARCTModule/UARCTMessageCenter.m
+++ b/ios/UARCTModule/UARCTMessageCenter.m
@@ -27,13 +27,13 @@ int const UARCTErrorCodeInboxRefreshFailed = 1;
 
 - (void)showInboxMessage:(UAInboxMessage *)message {
     if ([[NSUserDefaults standardUserDefaults] boolForKey:UARCTAutoLaunchMessageCenterKey]) {
-        [[UAirship defaultMessageCenter] displayMessageForID:message.messageID];
+        [[UAirship messageCenter] displayMessageForID:message.messageID];
     }
 }
 
 - (void)showInbox {
     if ([[NSUserDefaults standardUserDefaults] boolForKey:UARCTAutoLaunchMessageCenterKey]) {
-        [[UAirship defaultMessageCenter] display];
+        [[UAirship messageCenter] display];
     }
 }
 

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -328,13 +328,13 @@ RCT_REMAP_METHOD(getBadgeNumber,
 
 RCT_EXPORT_METHOD(displayMessageCenter) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[UAirship defaultMessageCenter] display];
+        [[UAirship messageCenter] display];
     });
 }
 
 RCT_EXPORT_METHOD(dismissMessageCenter) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[UAirship defaultMessageCenter] dismiss];
+        [[UAirship messageCenter] dismiss];
     });
 }
 
@@ -510,4 +510,3 @@ RCT_REMAP_METHOD(getActiveNotifications,
     }
 }
 @end
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/sample/AirshipSample/ios/Podfile.lock
+++ b/sample/AirshipSample/ios/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - UrbanAirship-iOS-AppExtensions (9.0.1)
-  - UrbanAirship-iOS-SDK (9.0.1)
+  - UrbanAirship-iOS-AppExtensions (9.0.2)
+  - UrbanAirship-iOS-SDK (9.0.2)
 
 DEPENDENCIES:
   - UrbanAirship-iOS-AppExtensions
   - UrbanAirship-iOS-SDK
 
 SPEC CHECKSUMS:
-  UrbanAirship-iOS-AppExtensions: 521ccf071fd0401a45bb0c322368de7385b5b841
-  UrbanAirship-iOS-SDK: 281c24629c81c5f75a6c186a202361dfa9828a22
+  UrbanAirship-iOS-AppExtensions: 3f63a1b8b2a454d8fcbb9bbe04361398f26df246
+  UrbanAirship-iOS-SDK: 402eb69c5b7603879581ad3180be0b70bda725aa
 
 PODFILE CHECKSUM: 318fbed798b9ecf4971cb154cd13d6ea8c25cefe
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.4.0


### PR DESCRIPTION
Fixes an issue with iOS SDK 9.0 `deafultMessageCenter` => `messageCenter`. Tested on a simulator. 