### PR TITLE
[GH-73] Add show inbox event

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/events/PushReceivedEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/PushReceivedEvent.java
@@ -1,4 +1,4 @@
-/* Copyright 2017 Urban Airship and Contributors */
+ /* Copyright 2017 Urban Airship and Contributors */
 
 package com.urbanairship.reactnative.events;
 

--- a/android/src/main/java/com/urbanairship/reactnative/events/ShowInboxEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/ShowInboxEvent.java
@@ -1,0 +1,49 @@
+/* Copyright 2017 Urban Airship and Contributors */
+
+package com.urbanairship.reactnative.events;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.urbanairship.reactnative.Event;
+
+/**
+ * Show inbox event.
+ */
+public class ShowInboxEvent implements Event {
+
+    private static final String SHOW_INBOX_EVENT = "com.urbanairship.show_inbox";
+    private static final String MESSAGE_ID = "messageId";
+
+    private final String messageId;
+
+    /**
+     * Default constructor.
+     *
+     * @param messageId The optional message ID.
+     */
+    public ShowInboxEvent(@Nullable String messageId) {
+        this.messageId = messageId;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return SHOW_INBOX_EVENT;
+    }
+
+    @NonNull
+    @Override
+    public WritableMap getBody() {
+        WritableMap map = Arguments.createMap();
+        map.putString(MESSAGE_ID, messageId);
+        return map;
+    }
+
+    @Override
+    public boolean isCritical() {
+        return true;
+    }
+}

--- a/ios/UARCTModule/UARCTEventEmitter.h
+++ b/ios/UARCTModule/UARCTEventEmitter.h
@@ -49,6 +49,17 @@ extern NSString *const UARCTNotificationPresentationSoundKey;
 - (void)inboxUpdated;
 
 /**
+ * Sends an show inbox event.
+ */
+- (void)showInbox;
+
+/**
+ * Sends an show inbox message event.
+ * @param messageID The message ID.
+ */
+- (void)showInboxMessage:(NSString *)messageID;
+
+/**
  * Creates a push map for a given notification content.
  * @param content The notification content.
  * @return Push map.

--- a/ios/UARCTModule/UARCTEventEmitter.m
+++ b/ios/UARCTModule/UARCTEventEmitter.m
@@ -14,6 +14,7 @@ NSString *const UARCTPushReceivedEventName= @"com.urbanairship.push_received";
 NSString *const UARCTDeepLinkEventName = @"com.urbanairship.deep_link";
 NSString *const UARCTOptInStatusChangedEventName = @"com.urbanairship.notification_opt_in_status";
 NSString *const UARCTInboxUpdatedEventName = @"com.urbanairship.inbox_updated";
+NSString *const UARCTShowInboxEventName = @"com.urbanairship.show_inbox";
 
 NSString *const UARCTNotificationPresentationAlertKey = @"alert";
 NSString *const UARCTNotificationPresentationBadgeKey = @"badge";
@@ -169,6 +170,19 @@ static UARCTEventEmitter *sharedEventEmitter_;
                             };
 
     [self sendEventWithName:UARCTInboxUpdatedEventName body:body];
+}
+
+- (void)showInbox {
+    [self showInboxMessage:nil];
+}
+
+- (void)showInboxMessage:(NSString *)messageID {
+    NSMutableDictionary *body = [NSMutableDictionary dictionary];
+    [body setValue:messageID forKey:@"messageId"];
+
+    if (![self sendEventWithName:UARCTShowInboxEventName body:body]) {
+        [self.pendingEvents addObject:@{ @"name": UARCTShowInboxEventName, @"body": body }];
+    }
 }
 
 #pragma mark -

--- a/ios/UARCTModule/UARCTMessageCenter.m
+++ b/ios/UARCTModule/UARCTMessageCenter.m
@@ -1,6 +1,7 @@
 /* Copyright 2017 Urban Airship and Contributors */
 
 #import "UARCTMessageCenter.h"
+#import "UARCTEventEmitter.h"
 
 @implementation UARCTMessageCenter
 static UARCTMessageCenter *sharedMessageCenterDelegate_;
@@ -25,15 +26,19 @@ int const UARCTErrorCodeInboxRefreshFailed = 1;
 
 #pragma mark UAInboxDelegate
 
-- (void)showInboxMessage:(UAInboxMessage *)message {
+- (void)showMessageForID:(NSString *)messageID {
     if ([[NSUserDefaults standardUserDefaults] boolForKey:UARCTAutoLaunchMessageCenterKey]) {
-        [[UAirship messageCenter] displayMessageForID:message.messageID];
+        [[UAirship messageCenter] displayMessageForID:messageID];
+    } else {
+        [[UARCTEventEmitter shared] showInboxMessage:messageID];
     }
 }
 
 - (void)showInbox {
     if ([[NSUserDefaults standardUserDefaults] boolForKey:UARCTAutoLaunchMessageCenterKey]) {
         [[UAirship messageCenter] display];
+    } else {
+        [[UARCTEventEmitter shared] showInbox];
     }
 }
 

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -19,6 +19,7 @@ const PUSH_RECEIVED_EVENT = "com.urbanairship.push_received";
 const DEEP_LINK_EVENT = "com.urbanairship.deep_link";
 const INBOX_UPDATED_EVENT = "com.urbanairship.inbox_updated";
 const NOTIFICATION_OPT_IN_STATUS = "com.urbanairship.notification_opt_in_status";
+const SHOW_INBOX_EVENT = "com.urbanairship.show_inbox";
 
 /**
  * @private
@@ -36,6 +37,8 @@ function convertEventEnum(type: UAEventName): ?string {
     return NOTIFICATION_OPT_IN_STATUS;
   } else if (type == 'inboxUpdated') {
     return INBOX_UPDATED_EVENT;
+  } else if (type == 'showInbox') {
+    return SHOW_INBOX_EVENT;
   }
   throw new Error("Invalid event name: " + type);
 }
@@ -45,7 +48,9 @@ export type UAEventName = $Enum<{
   pushReceived: string,
   register: string,
   deepLink: string,
-  notificationOptInStatus: string
+  notificationOptInStatus: string,
+  inboxUpdated: string,
+  showInbox: string
 }>;
 
 /**
@@ -103,14 +108,23 @@ export type UAEventName = $Enum<{
  * @param {boolean} notificationOptions.badge If the user is opted into badge updates.
  */
 
- /**
-  * Event fired when the inbox is updated.
-  *
-  * @event UrbanAirship#inboxUpdated
-  * @type {object}
-  * @param {number} messageUnreadCount The message unread count.
-  * @param {number} messageCount THe total message count.
-  */
+/**
+ * Event fired when the inbox is updated.
+ *
+ * @event UrbanAirship#inboxUpdated
+ * @type {object}
+ * @param {number} messageUnreadCount The message unread count.
+ * @param {number} messageCount The total message count.
+ */
+
+/**
+ * Event fired when the inbox needs to be displayed. This event is only emitted if
+ * auto launch message center is disabled.
+ *
+ * @event UrbanAirship#showInbox
+ * @type {object}
+ * @param {string} [messageId] The optional message ID.
+ */
 
 /**
  * The main Urban Airship API.


### PR DESCRIPTION
Adds an event to show the inbox if auto launch message center is disabled. Needed to route all inbox events through the application if the app built an react native message center.

Testing:
 - Verified it works on iOS and Android