### PR TITLE
[MOBILE-179] Queue up push received and registration events

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -29,7 +29,7 @@ class EventEmitter {
 
 
     private long listenerCount;
-    private final List<Event> pendingEvents = new ArrayList<>();
+    private List<Event> pendingEvents = new ArrayList<>();
     private Set<String> knownListeners = new HashSet<>();
 
     private static EventEmitter sharedInstance = new EventEmitter();
@@ -121,17 +121,18 @@ class EventEmitter {
      */
     void addAndroidListener(ReactContext reactContext, String eventName) {
         synchronized (knownListeners) {
-            List<Event> pending = pendingEvents;
+            List<Event> pending = new ArrayList<>();
+            pending.addAll(pendingEvents);
 
-            for (Event event : pending) {
-                if (event.getName().equals(eventName)) {
+            for (Event event : pendingEvents) {
+                if (event.equals(eventName)) {
                     sendEvent(reactContext, event);
-                    pendingEvents.remove(event);
+                    pending.remove(event);
                 }
             }
 
-            setEnabled(reactContext, true);
-
+            pendingEvents.clear();
+            pendingEvents.addAll(pending);
 
             listenerCount++;
             knownListeners.add(eventName);
@@ -150,7 +151,7 @@ class EventEmitter {
 
             if (listenerCount == 0) {
                 setEnabled(reactContext, false);
-                knownListeners.removeAll(knownListeners);
+                knownListeners.clear();
             }
         }
     }

--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -16,7 +16,9 @@ import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.urbanairship.Logger;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Emits events to listeners in the JS layer.
@@ -26,6 +28,7 @@ class EventEmitter {
 
     long listenerCount;
     List<Event> pendingEvents = new ArrayList<>();
+    Set<String> knownListeners = new HashSet<>();
 
     private static EventEmitter sharedInstance = new EventEmitter();
 
@@ -77,7 +80,7 @@ class EventEmitter {
             new Handler(Looper.getMainLooper()).post(new Runnable() {
                 @Override
                 public void run() {
-                    if (listenerCount > 0) {
+                    if (listenerCount > 0 && knownListeners.contains(event)) {
                         sendEvent(applicationContext, event);
                     } else {
                         synchronized (pendingEvents) {
@@ -109,6 +112,23 @@ class EventEmitter {
             });
         }
     }
+
+    /**
+     * Helper method to add known listeners.
+     *
+     * @param eventName The event name identifying the listener.
+     */
+    void addKnownListener(String eventName) {
+        knownListeners.add(eventName);
+    }
+
+    /**
+     * Helper method to remove all known listeners.
+     */
+    void removeKnownListeners() {
+        knownListeners.removeAll(knownListeners);
+    }
+
 
     /**
      * Helper method to emit data.

--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -80,7 +80,7 @@ class EventEmitter {
             new Handler(Looper.getMainLooper()).post(new Runnable() {
                 @Override
                 public void run() {
-                    if (listenerCount > 0 && knownListeners.contains(event)) {
+                    if (knownListeners.contains(event.getName())) {
                         sendEvent(applicationContext, event);
                     } else {
                         synchronized (pendingEvents) {

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -60,6 +60,7 @@ import static com.urbanairship.actions.ActionResult.STATUS_EXECUTION_ERROR;
 import static com.urbanairship.actions.ActionResult.STATUS_REJECTED_ARGUMENTS;
 import static com.urbanairship.reactnative.Utils.convertDynamic;
 import static com.urbanairship.reactnative.Utils.convertJsonValue;
+import static java.lang.Math.max;
 
 /**
  * React module for Urban Airship.
@@ -127,23 +128,22 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void addAndroidListener(String eventName) {
         Logger.info("UrbanAirshipReactModule - Event listener added: " + eventName);
-        EventEmitter.shared().listenerCount++;
-        EventEmitter.shared().addKnownListener(eventName);
 
         List<Event> pending = EventEmitter.shared().pendingEvents;
 
-        if (pending.size() > 0) {
-            for (Event event: pending) {
-                if (event.getName() == eventName) {
+        synchronized (EventEmitter.shared().pendingEvents) {
+            for (Event event : pending) {
+                if (event.getName().equals(eventName)) {
                     EventEmitter.shared().sendEvent(getReactApplicationContext(), event);
-                    synchronized (EventEmitter.shared().pendingEvents) {
-                        EventEmitter.shared().pendingEvents.remove(event);
-                    }
+                    EventEmitter.shared().pendingEvents.remove(event);
                 }
             }
+
+            EventEmitter.shared().setEnabled(getReactApplicationContext(), true);
         }
 
-        EventEmitter.shared().setEnabled(getReactApplicationContext(), true);
+        EventEmitter.shared().listenerCount++;
+        EventEmitter.shared().addKnownListener(eventName);
     }
 
     /**
@@ -155,10 +155,8 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     public void removeAndroidListeners(int count) {
         Logger.info("UrbanAirshipReactModule - Event listeners removed: " + count);
 
-        EventEmitter.shared().listenerCount -= count;
-        if (EventEmitter.shared().listenerCount < 0) {
-            EventEmitter.shared().listenerCount = 0;
-        }
+        long currentCount = EventEmitter.shared().listenerCount;
+        EventEmitter.shared().listenerCount = max(0, currentCount - count);
 
         if (EventEmitter.shared().listenerCount == 0) {
             EventEmitter.shared().setEnabled(getReactApplicationContext(), false);

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -52,6 +52,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
+import java.util.List;
 
 import static com.urbanairship.actions.ActionResult.STATUS_ACTION_NOT_FOUND;
 import static com.urbanairship.actions.ActionResult.STATUS_COMPLETED;
@@ -127,8 +128,9 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     public void addAndroidListener(String eventName) {
         Logger.info("UrbanAirshipReactModule - Event listener added: " + eventName);
         EventEmitter.shared().listenerCount++;
+        EventEmitter.shared().addKnownListener(eventName);
 
-        ArrayList<Event> pending = EventEmitter.shared().pendingEvents;
+        List<Event> pending = EventEmitter.shared().pendingEvents;
 
         if (pending.size() > 0) {
             for (Event event: pending) {
@@ -160,6 +162,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
 
         if (EventEmitter.shared().listenerCount == 0) {
             EventEmitter.shared().setEnabled(getReactApplicationContext(), false);
+            EventEmitter.shared().removeKnownListeners();
         }
     }
 
@@ -742,11 +745,11 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
 
 
 
-        /**
-         * Forces the inbox to refresh. This is normally not needed as the inbox will automatically refresh on foreground or when a push arrives thats associated with a message.
-         *
-         * @param promise The JS promise.
-         */
+    /**
+     * Forces the inbox to refresh. This is normally not needed as the inbox will automatically refresh on foreground or when a push arrives thats associated with a message.
+     *
+     * @param promise The JS promise.
+     */
     @ReactMethod
     public  void refreshInbox(final Promise promise)  {
         UAirship.shared().getInbox().fetchMessages(new RichPushInbox.FetchMessagesCallback() {
@@ -755,7 +758,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
                 if (success) {
                     promise.resolve(true);
                 } else {
-                   promise.reject("STATUS_DID_NOT_REFRESH","Inbox failed to refresh");
+                    promise.reject("STATUS_DID_NOT_REFRESH","Inbox failed to refresh");
                 }
             }
         });

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -60,7 +60,6 @@ import static com.urbanairship.actions.ActionResult.STATUS_EXECUTION_ERROR;
 import static com.urbanairship.actions.ActionResult.STATUS_REJECTED_ARGUMENTS;
 import static com.urbanairship.reactnative.Utils.convertDynamic;
 import static com.urbanairship.reactnative.Utils.convertJsonValue;
-import static java.lang.Math.max;
 
 /**
  * React module for Urban Airship.
@@ -128,22 +127,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void addAndroidListener(String eventName) {
         Logger.info("UrbanAirshipReactModule - Event listener added: " + eventName);
-
-        List<Event> pending = EventEmitter.shared().pendingEvents;
-
-        synchronized (EventEmitter.shared().pendingEvents) {
-            for (Event event : pending) {
-                if (event.getName().equals(eventName)) {
-                    EventEmitter.shared().sendEvent(getReactApplicationContext(), event);
-                    EventEmitter.shared().pendingEvents.remove(event);
-                }
-            }
-
-            EventEmitter.shared().setEnabled(getReactApplicationContext(), true);
-        }
-
-        EventEmitter.shared().listenerCount++;
-        EventEmitter.shared().addKnownListener(eventName);
+        EventEmitter.shared().addAndroidListener(getReactApplicationContext(), eventName);
     }
 
     /**
@@ -154,14 +138,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void removeAndroidListeners(int count) {
         Logger.info("UrbanAirshipReactModule - Event listeners removed: " + count);
-
-        long currentCount = EventEmitter.shared().listenerCount;
-        EventEmitter.shared().listenerCount = max(0, currentCount - count);
-
-        if (EventEmitter.shared().listenerCount == 0) {
-            EventEmitter.shared().setEnabled(getReactApplicationContext(), false);
-            EventEmitter.shared().removeKnownListeners();
-        }
+        EventEmitter.shared().removeAndroidListeners(getReactApplicationContext(), count);
     }
 
     /**


### PR DESCRIPTION
This is cleaned up work from PR#90. 

- drops isCritical in Android
- adds functionality to only emit pending events when a matching listener is added in both iOS and Android