### PR TITLE
[MOBILE-48] fix repo ordering, update gradle build tools

### DIFF
--- a/sample/AirshipSample/android/build.gradle
+++ b/sample/AirshipSample/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.google.gms:google-services:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -16,12 +16,12 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         mavenLocal()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
-        google()
     }
 }


### PR DESCRIPTION
This fixes an error I was coming across when getting CI working. The ordering of the repositories matters here, for whatever reason. Also updated gradle build tools while I was at it.