### PR TITLE
[MOBILE-239] add support for iOS authorized settings

### DIFF
--- a/ios/UARCTModule/UARCTAutopilot.m
+++ b/ios/UARCTModule/UARCTAutopilot.m
@@ -6,7 +6,7 @@
 #import "UARCTMessageCenter.h"
 
 NSString *const UARCTPresentationOptionsStorageKey = @"com.urbanairship.presentation_options";
-NSString *const UARCTAirshipKitRecommendedVersion = @"9.0.5";
+NSString *const UARCTAirshipKitRecommendedVersion = @"9.3.2";
 
 @implementation UARCTAutopilot
 

--- a/ios/UARCTModule/UARCTEventEmitter.m
+++ b/ios/UARCTModule/UARCTEventEmitter.m
@@ -21,6 +21,13 @@ NSString *const UARCTNotificationPresentationAlertKey = @"alert";
 NSString *const UARCTNotificationPresentationBadgeKey = @"badge";
 NSString *const UARCTNotificationPresentationSoundKey = @"sound";
 
+NSString *const UARCTAuthorizedNotificationSettingsAlertKey = UARCTNotificationPresentationAlertKey;
+NSString *const UARCTAuthorizedNotificationSettingsBadgeKey = UARCTNotificationPresentationBadgeKey;
+NSString *const UARCTAuthorizedNotificationSettingsSoundKey = UARCTNotificationPresentationSoundKey;
+NSString *const UARCTAuthorizedNotificationSettingsCarPlayKey = @"carPlay";
+NSString *const UARCTAuthorizedNotificationSettingsLockScreenKey = @"lockScreen";
+NSString *const UARCTAuthorizedNotificationSettingsNotificationCenterKey = @"notificationCenter";
+
 NSString *const UARCTEventNameKey = @"name";
 NSString *const UARCTEventBodyKey = @"body";
 
@@ -140,34 +147,56 @@ static UARCTEventEmitter *sharedEventEmitter_;
     [self sendEventWithName:UARCTRegistrationEventName body:registrationBody];
 }
 
-- (void)notificationAuthorizedOptionsDidChange:(UANotificationOptions)options {
+- (void)notificationAuthorizedSettingsDidChange:(UAAuthorizedNotificationSettings)authorizedSettings {
     BOOL optedIn = NO;
 
     BOOL alertBool = NO;
     BOOL badgeBool = NO;
     BOOL soundBool = NO;
+    BOOL carPlayBool = NO;
+    BOOL lockScreenBool = NO;
+    BOOL notificationCenterBool = NO;
 
-    if (options & UANotificationOptionAlert) {
+    if (authorizedSettings & UAAuthorizedNotificationSettingsAlert) {
         alertBool = YES;
     }
 
-    if (options & UANotificationOptionBadge) {
+    if (authorizedSettings & UAAuthorizedNotificationSettingsBadge) {
         badgeBool = YES;
     }
 
-    if (options & UANotificationOptionSound) {
+    if (authorizedSettings & UAAuthorizedNotificationSettingsSound) {
         soundBool = YES;
     }
 
-    optedIn = alertBool || badgeBool || soundBool;
+    if (authorizedSettings & UAAuthorizedNotificationSettingsCarPlay) {
+        carPlayBool = YES;
+    }
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsLockScreen) {
+        lockScreenBool = YES;
+    }
+
+    if (authorizedSettings & UAAuthorizedNotificationSettingsNotificationCenter) {
+        notificationCenterBool = YES;
+    }
+
+    optedIn = authorizedSettings != UAAuthorizedNotificationSettingsNone;
 
     NSDictionary *body = @{  @"optIn": @(optedIn),
                              @"notificationOptions" : @{
-                                     UARCTNotificationPresentationAlertKey : @(alertBool),
-                                     UARCTNotificationPresentationBadgeKey : @(badgeBool),
-                                     UARCTNotificationPresentationSoundKey : @(soundBool) }
-                             };
-
+                                     UARCTAuthorizedNotificationSettingsAlertKey : @(alertBool),
+                                     UARCTAuthorizedNotificationSettingsBadgeKey : @(badgeBool),
+                                     UARCTAuthorizedNotificationSettingsSoundKey : @(soundBool)
+                             },
+                             @"authorizedNotificationSettings" : @{
+                                     UARCTAuthorizedNotificationSettingsAlertKey : @(alertBool),
+                                     UARCTAuthorizedNotificationSettingsBadgeKey : @(badgeBool),
+                                     UARCTAuthorizedNotificationSettingsSoundKey : @(soundBool),
+                                     UARCTAuthorizedNotificationSettingsCarPlayKey : @(carPlayBool),
+                                     UARCTAuthorizedNotificationSettingsLockScreenKey : @(lockScreenBool),
+                                     UARCTAuthorizedNotificationSettingsNotificationCenterKey : @(notificationCenterBool)
+                             }};
 
     [self sendEventWithName:UARCTOptInStatusChangedEventName body:body];
 }

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -60,7 +60,7 @@ RCT_REMAP_METHOD(isUserNotificationsEnabled,
 RCT_REMAP_METHOD(isUserNotificationsOptedIn,
                  isUserNotificationsOptedIn_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    BOOL optedIn = [UAirship push].authorizedNotificationOptions != 0;
+    BOOL optedIn = [UAirship push].authorizedNotificationSettings != 0;
     resolve(@(optedIn));
 }
 

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -64,7 +64,7 @@ export type UAEventName = $Enum<{
  * @param {string} notification.notificationId The notification ID.
  * @param {object} notification.extras Any push extras.
  * @param {string=} actionId The ID of the notification action button if available.
- * @param {boolean} isForeground Will always be true if the user taps the main notification. Otherwise its defined by the notificaiton action button.
+ * @param {boolean} isForeground Will always be true if the user taps the main notification. Otherwise its defined by the notification action button.
  */
 
 /**
@@ -102,10 +102,13 @@ export type UAEventName = $Enum<{
  * @event UrbanAirship#notificationOptInStatus
  * @type {object}
  * @param {boolean} optIn If the user is opted in or not to user notifications.
- * @param {object} [notificationOptions] iOS only. A map of opted in options.
- * @param {boolean} notificationOptions.alert If the user is opted into alerts.
- * @param {boolean} notificationOptions.sound If the user is opted into sounds.
- * @param {boolean} notificationOptions.badge If the user is opted into badge updates.
+ * @param {object} [authorizedNotificationSettings] iOS only. A map of authorized settings.
+ * @param {boolean} authorizedNotificationSettings.alert If alerts are authorized.
+ * @param {boolean} authorizedNotificationSettings.sound If sounds are authorized.
+ * @param {boolean} authorizedNotificationSettings.badge If badges are authorized.
+ * @param {boolean} authorizedNotificationSettings.carPlay If car play is authorized.
+ * @param {boolean} authorizedNotificationSettings.lockScreen If the lock screen is authorized.
+ * @param {boolean} authorizedNotificationSettings.notificationCenter If the notification center is authorized.
  */
 
 /**
@@ -565,9 +568,9 @@ class UrbanAirship {
   }
 
   /**
-   * Clears all notificaitons for the application.
+   * Clears all notifications for the application.
    * Supported on Android and iOS 10+. For older iOS devices, you can set
-   * the badge number to 0 to clear notificaitons.
+   * the badge number to 0 to clear notifications.
    *
    * @param {boolean} [enabled=true] true to automatically launch the default message center, false to disable.
    */
@@ -580,7 +583,7 @@ class UrbanAirship {
    * Supported on Android and iOS 10+.
    *
    * @param {string} identifier The notification identifier. The identifier will
-   * available in the pushReceived event and in the active notificaiton response
+   * available in the pushReceived event and in the active notification response
    * under the "notificationId" field.
    */
   static clearNotification(identifier: string) {

--- a/sample/AirshipSample/ios/AirshipSample.xcodeproj/project.pbxproj
+++ b/sample/AirshipSample/ios/AirshipSample.xcodeproj/project.pbxproj
@@ -629,7 +629,6 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				FF905C99F424B3813F7A98C6 /* [CP] Embed Pods Frameworks */,
-				9D331DA0422AAA6755480151 /* [CP] Copy Pods Resources */,
 				99912C6F1ECB77A500295C67 /* Embed App Extensions */,
 			);
 			buildRules = (
@@ -689,7 +688,6 @@
 				99912C451ECB77A500295C67 /* Sources */,
 				99912C461ECB77A500295C67 /* Frameworks */,
 				99912C471ECB77A500295C67 /* Resources */,
-				A08F3684C094E551F3DDF453 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1129,36 +1127,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		9D331DA0422AAA6755480151 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AirshipSample Cocoapods/Pods-AirshipSample Cocoapods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A08F3684C094E551F3DDF453 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ServiceExtension Cocoapods/Pods-ServiceExtension Cocoapods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		FF905C99F424B3813F7A98C6 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/sample/AirshipSample/ios/Podfile.lock
+++ b/sample/AirshipSample/ios/Podfile.lock
@@ -1,15 +1,20 @@
 PODS:
-  - UrbanAirship-iOS-AppExtensions (9.0.2)
-  - UrbanAirship-iOS-SDK (9.0.2)
+  - UrbanAirship-iOS-AppExtensions (9.3.2)
+  - UrbanAirship-iOS-SDK (9.3.2)
 
 DEPENDENCIES:
   - UrbanAirship-iOS-AppExtensions
   - UrbanAirship-iOS-SDK
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - UrbanAirship-iOS-AppExtensions
+    - UrbanAirship-iOS-SDK
+
 SPEC CHECKSUMS:
-  UrbanAirship-iOS-AppExtensions: 3f63a1b8b2a454d8fcbb9bbe04361398f26df246
-  UrbanAirship-iOS-SDK: 402eb69c5b7603879581ad3180be0b70bda725aa
+  UrbanAirship-iOS-AppExtensions: 868cc0ffcb54434848a33d1292ae5b8a530b9d88
+  UrbanAirship-iOS-SDK: f5d4c71d2a3e7685e6f1a73fd1ad62a5884bdc33
 
 PODFILE CHECKSUM: 318fbed798b9ecf4971cb154cd13d6ea8c25cefe
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.2


### PR DESCRIPTION

### What do these changes do?
Adds support for authorized notification settings and targets iOS SDK 9.3.2. This is effectively identical to the related work on cordova. Also fixed several misspellings of "notification".

### How did you verify these changes?
Manual testing, making sure the plugin builds and the sample app runs properly.