### PR TITLE
2.0 fixes

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -44,7 +44,7 @@ workspace.
 
 2) Create the `airshipconfig.properties` file in `src/main/assets`
 
-3) If using FCM, add your `google-services.json` file in `sample/AirshipSample/Android/app`
+3) If using FCM, add your `google-services.json` file in `sample/AirshipSample/android/app`
 
 4) Start the webserver by running `react-native start` in `sample/AirshipSample`
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,5 +13,5 @@ android {
 dependencies {
     compile 'com.facebook.react:react-native:[0.40,)'
     compile 'com.urbanairship.android:urbanairship-fcm:9.4.1'
-    compile 'com.google.firebase:firebase-core:16.0.0'
+    compile 'com.google.firebase:firebase-core:16.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,5 +13,5 @@ android {
 dependencies {
     compile 'com.facebook.react:react-native:[0.40,)'
     compile 'com.urbanairship.android:urbanairship-fcm:9.4.1'
-    compile 'com.google.firebase:firebase-core:17.0.0'
+    compile 'com.google.firebase:firebase-core:16.0.0'
 }

--- a/sample/AirshipSample/android/app/build.gradle
+++ b/sample/AirshipSample/android/app/build.gradle
@@ -86,7 +86,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        applicationId "com.airshipsample"
+        applicationId "com.urbanairship.sample"
         minSdkVersion 16
         targetSdkVersion 27
         versionCode 1

--- a/sample/AirshipSample/android/app/src/main/AndroidManifest.xml
+++ b/sample/AirshipSample/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.airshipsample"
+    package="com.urbanairship.sample"
     android:versionCode="1"
     android:versionName="1.0">
 

--- a/sample/AirshipSample/android/app/src/main/java/com/urbanairship/sample/MainActivity.java
+++ b/sample/AirshipSample/android/app/src/main/java/com/urbanairship/sample/MainActivity.java
@@ -1,4 +1,4 @@
-package com.airshipsample;
+package com.urbanairship.sample;
 
 import com.facebook.react.ReactActivity;
 

--- a/sample/AirshipSample/android/app/src/main/java/com/urbanairship/sample/MainApplication.java
+++ b/sample/AirshipSample/android/app/src/main/java/com/urbanairship/sample/MainApplication.java
@@ -1,8 +1,9 @@
-package com.airshipsample;
+package com.urbanairship.sample;
 
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.urbanairship.reactnative.BuildConfig;
 import com.urbanairship.reactnative.ReactAirshipPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;

--- a/sample/README.md
+++ b/sample/README.md
@@ -8,7 +8,7 @@ A basic sample application that integrates the Urban Airship React Native module
 
 2) Create airship config files:
   - iOS: AirshipSample/iOS/AirshipConfig.plist
-  - Android: AirshipSample/android/app/src/main/assets/airshipconfig.properites
+  - Android: AirshipSample/android/app/src/main/assets/airshipconfig.properties
 
 3) Install AirshipKit for iOS with one of the following methods:
  - Carthage: Run `carthage update` in `AirshipSample/ios`


### PR DESCRIPTION

### What do these changes do?
This reverts the change to the firebase core dependency, and also restructures the sample app to have the same package structure as our main android sample, so that it's compatible with the google-services.json and easier to test. Feel free to suggest otherwise, it just seemed like a good thing to do.

### Why are these changes necessary?
I accidentally put in the wrong version number for firebase core and in the rush to get it out didn't realize that it broke the build.

### How did you verify these changes?
Made sure the android sample builds and runs correctly with this change. This may still require extra work to get around the cryptic "window error" that bdb was reporting this morning, and which appears to be tooling related.