### PR TITLE
add react to header search path

### DIFF
--- a/ios/UARCTModule.xcodeproj/project.pbxproj
+++ b/ios/UARCTModule.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/AirshipKit.framework/**",
 					"$(AIRSHIP_SEARCH_PATH)/AirshipKit.framework/**",
 					"$(AIRSHIP_SEARCH_PATH)/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = (
@@ -218,6 +219,7 @@
 					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/AirshipKit.framework/**",
 					"$(AIRSHIP_SEARCH_PATH)/AirshipKit.framework/**",
 					"$(AIRSHIP_SEARCH_PATH)/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = (


### PR DESCRIPTION
### What do these changes do?
This PR adds another path to the "Header Search Paths" of the xcode project.

### Why are these changes necessary?
We are using detached ExpoKit, and experienced the same issue as #128 

The [solution listed there](https://github.com/urbanairship/react-native-module/issues/128#issuecomment-405014395) worked for us, but the instructed change is inside the `node_modules` folder, so it does not get tracked by git, and is not a full fix.

This change allows our build to succeed after a fresh installation of node dependencies.

### How did you verify these changes?

1. Create a new app with CRNA
1. Eject with ExpoKit
1. Install this library - observe issue #128 
1. Install forked version
1. Observe build succeeds

#### Verification Screenshots:
ℹ If applicable, please provide screenshots here.

### Anything else a reviewer should know?
Looks like there are already some maybe-used search paths already (e.g. Carthage), so adding another probably won't be a big deal.

Thanks UA team!
-David
