### PR TITLE
GH-148: Fix Android pending events

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/Event.java
+++ b/android/src/main/java/com/urbanairship/reactnative/Event.java
@@ -24,12 +24,4 @@ public interface Event {
      */
     @NonNull
     WritableMap getBody();
-
-    /**
-     * If the event is critical. Critical events will be stored as a pending event until the
-     * react context is ready.
-     *
-     * @return {@code true} if the event is critical, otherwise {@code false}.
-     */
-    boolean isCritical();
 }

--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -27,34 +27,21 @@ import static java.lang.Math.max;
  */
 class EventEmitter {
 
-    private static EventEmitter sharedInstance;
+    private static EventEmitter sharedInstance = new EventEmitter();
 
     private final List<Event> pendingEvents = new ArrayList<>();
     private final Set<String> knownListeners = new HashSet<>();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
-    private final Context context;
 
     private long listenerCount;
     private ReactContext reactContext;
-
-    private EventEmitter(Context context) {
-        this.context = context.getApplicationContext();
-    }
 
     /**
      * Returns the shared {@link EventEmitter} instance.
      *
      * @return The shared {@link EventEmitter} instance.
      */
-    static EventEmitter shared(Context context) {
-        if (sharedInstance == null) {
-            synchronized (EventEmitter.class) {
-                if (sharedInstance == null) {
-                    sharedInstance = new EventEmitter(context);
-                }
-            }
-        }
-
+    static EventEmitter shared() {
         return sharedInstance;
     }
 

--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -150,7 +150,7 @@ class EventEmitter {
     @MainThread
     private boolean emit(final Event event) {
         ReactContext reactContext = this.reactContext;
-        if (reactContext == null || reactContext.hasActiveCatalystInstance()) {
+        if (reactContext == null || !reactContext.hasActiveCatalystInstance()) {
             return false;
         }
 

--- a/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
+++ b/android/src/main/java/com/urbanairship/reactnative/EventEmitter.java
@@ -120,8 +120,9 @@ class EventEmitter {
         synchronized (knownListeners) {
             for (Event event : new ArrayList<>(pendingEvents)) {
                 if (knownListeners.contains(event.getName())) {
+                    // Remove the event first before attempting to send. If it fails to
+                    // send it will get added back to pendingEvents.
                     pendingEvents.remove(event);
-                    // Send event will add the event back as pending
                     sendEvent(event);
                 }
             }

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAirshipReceiver.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAirshipReceiver.java
@@ -22,7 +22,7 @@ public class ReactAirshipReceiver extends AirshipReceiver {
     @Override
     protected void onChannelCreated(@NonNull Context context, @NonNull String channelId) {
         Event event = new RegistrationEvent(channelId, UAirship.shared().getPushManager().getRegistrationToken());
-        EventEmitter.shared(context).sendEvent(event);
+        EventEmitter.shared().sendEvent(event);
 
         // If the opt-in status changes send an event
         UrbanAirshipReactModule.checkOptIn(context);
@@ -31,7 +31,7 @@ public class ReactAirshipReceiver extends AirshipReceiver {
     @Override
     protected void onChannelUpdated(@NonNull Context context, @NonNull String channelId) {
         Event event = new RegistrationEvent(channelId, UAirship.shared().getPushManager().getRegistrationToken());
-        EventEmitter.shared(context).sendEvent(event);
+        EventEmitter.shared().sendEvent(event);
 
         // If the opt-in status changes send an event
         UrbanAirshipReactModule.checkOptIn(context);
@@ -42,27 +42,27 @@ public class ReactAirshipReceiver extends AirshipReceiver {
     protected void onPushReceived(@NonNull Context context, @NonNull PushMessage message, boolean notificationPosted) {
         if (!notificationPosted) {
             Event event = new PushReceivedEvent(message);
-            EventEmitter.shared(context).sendEvent(event);
+            EventEmitter.shared().sendEvent(event);
         }
     }
 
     @Override
     protected void onNotificationPosted(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Event event = new PushReceivedEvent(notificationInfo);
-        EventEmitter.shared(context).sendEvent(event);
+        EventEmitter.shared().sendEvent(event);
     }
 
     @Override
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo, @NonNull ActionButtonInfo actionButtonInfo) {
         Event event = new NotificationResponseEvent(notificationInfo, actionButtonInfo);
-        EventEmitter.shared(context).sendEvent(event);
+        EventEmitter.shared().sendEvent(event);
         return false;
     }
 
     @Override
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Event event = new NotificationResponseEvent(notificationInfo);
-        EventEmitter.shared(context).sendEvent(event);
+        EventEmitter.shared().sendEvent(event);
         return false;
     }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAirshipReceiver.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAirshipReceiver.java
@@ -22,7 +22,7 @@ public class ReactAirshipReceiver extends AirshipReceiver {
     @Override
     protected void onChannelCreated(@NonNull Context context, @NonNull String channelId) {
         Event event = new RegistrationEvent(channelId, UAirship.shared().getPushManager().getRegistrationToken());
-        EventEmitter.shared().sendEvent(context, event);
+        EventEmitter.shared(context).sendEvent(event);
 
         // If the opt-in status changes send an event
         UrbanAirshipReactModule.checkOptIn(context);
@@ -31,7 +31,7 @@ public class ReactAirshipReceiver extends AirshipReceiver {
     @Override
     protected void onChannelUpdated(@NonNull Context context, @NonNull String channelId) {
         Event event = new RegistrationEvent(channelId, UAirship.shared().getPushManager().getRegistrationToken());
-        EventEmitter.shared().sendEvent(context, event);
+        EventEmitter.shared(context).sendEvent(event);
 
         // If the opt-in status changes send an event
         UrbanAirshipReactModule.checkOptIn(context);
@@ -42,27 +42,27 @@ public class ReactAirshipReceiver extends AirshipReceiver {
     protected void onPushReceived(@NonNull Context context, @NonNull PushMessage message, boolean notificationPosted) {
         if (!notificationPosted) {
             Event event = new PushReceivedEvent(message);
-            EventEmitter.shared().sendEvent(context, event);
+            EventEmitter.shared(context).sendEvent(event);
         }
     }
 
     @Override
     protected void onNotificationPosted(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Event event = new PushReceivedEvent(notificationInfo);
-        EventEmitter.shared().sendEvent(context, event);
+        EventEmitter.shared(context).sendEvent(event);
     }
 
     @Override
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo, @NonNull ActionButtonInfo actionButtonInfo) {
         Event event = new NotificationResponseEvent(notificationInfo, actionButtonInfo);
-        EventEmitter.shared().sendEvent(context, event);
+        EventEmitter.shared(context).sendEvent(event);
         return false;
     }
 
     @Override
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
         Event event = new NotificationResponseEvent(notificationInfo);
-        EventEmitter.shared().sendEvent(context, event);
+        EventEmitter.shared(context).sendEvent(event);
         return false;
     }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
@@ -42,7 +42,7 @@ public class ReactAutopilot extends Autopilot {
                 String deepLink = arguments.getValue().getString();
                 if (deepLink != null) {
                     Event event = new DeepLinkEvent(deepLink);
-                    EventEmitter.shared(UAirship.getApplicationContext()).sendEvent(event);
+                    EventEmitter.shared().sendEvent(event);
                 }
                 return ActionResult.newResult(arguments.getValue());
             }
@@ -53,7 +53,7 @@ public class ReactAutopilot extends Autopilot {
             @Override
             public void onInboxUpdated() {
                 Event event = new InboxUpdatedEvent(UAirship.shared().getInbox().getUnreadCount(), UAirship.shared().getInbox().getCount());
-                EventEmitter.shared(UAirship.getApplicationContext()).sendEvent(event);
+                EventEmitter.shared().sendEvent(event);
             }
         });
 
@@ -100,7 +100,7 @@ public class ReactAutopilot extends Autopilot {
         }
 
         Event event = new ShowInboxEvent(messageId);
-        EventEmitter.shared(UAirship.getApplicationContext()).sendEvent(event);
+        EventEmitter.shared().sendEvent(event);
     }
 
     public static class CustomOverlayRichPushMessageAction extends OverlayRichPushMessageAction {

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
@@ -35,7 +35,6 @@ public class ReactAutopilot extends Autopilot {
     public void onAirshipReady(UAirship airship) {
         super.onAirshipReady(airship);
 
-
         // Modify the deep link action to emit events
         airship.getActionRegistry().getEntry(DeepLinkAction.DEFAULT_REGISTRY_NAME).setDefaultAction(new DeepLinkAction() {
             @Override
@@ -43,7 +42,7 @@ public class ReactAutopilot extends Autopilot {
                 String deepLink = arguments.getValue().getString();
                 if (deepLink != null) {
                     Event event = new DeepLinkEvent(deepLink);
-                    EventEmitter.shared().sendEvent(UAirship.getApplicationContext(), event);
+                    EventEmitter.shared(UAirship.getApplicationContext()).sendEvent(event);
                 }
                 return ActionResult.newResult(arguments.getValue());
             }
@@ -54,7 +53,7 @@ public class ReactAutopilot extends Autopilot {
             @Override
             public void onInboxUpdated() {
                 Event event = new InboxUpdatedEvent(UAirship.shared().getInbox().getUnreadCount(), UAirship.shared().getInbox().getCount());
-                EventEmitter.shared().sendEvent(UAirship.getApplicationContext(), event);
+                EventEmitter.shared(UAirship.getApplicationContext()).sendEvent(event);
             }
         });
 
@@ -101,7 +100,7 @@ public class ReactAutopilot extends Autopilot {
         }
 
         Event event = new ShowInboxEvent(messageId);
-        EventEmitter.shared().sendEvent(UAirship.getApplicationContext(), event);
+        EventEmitter.shared(UAirship.getApplicationContext()).sendEvent(event);
     }
 
     public static class CustomOverlayRichPushMessageAction extends OverlayRichPushMessageAction {

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -95,6 +95,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     public void initialize() {
         super.initialize();
 
+
         getReactApplicationContext().addLifecycleEventListener(new LifecycleEventListener() {
             @Override
             public void onHostResume() {
@@ -113,6 +114,8 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
             }
 
         });
+
+        EventEmitter.shared(getReactApplicationContext()).attachReactContext(getReactApplicationContext());
     }
 
     @Override
@@ -128,7 +131,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void addAndroidListener(String eventName) {
         Logger.info("UrbanAirshipReactModule - Event listener added: " + eventName);
-        EventEmitter.shared().addAndroidListener(getReactApplicationContext(), eventName);
+        EventEmitter.shared(getReactApplicationContext()).addAndroidListener(eventName);
     }
 
     /**
@@ -139,7 +142,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void removeAndroidListeners(int count) {
         Logger.info("UrbanAirshipReactModule - Event listeners removed: " + count);
-        EventEmitter.shared().removeAndroidListeners(getReactApplicationContext(), count);
+        EventEmitter.shared(getReactApplicationContext()).removeAndroidListeners(count);
     }
 
     /**
@@ -541,7 +544,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
         if (message == null) {
             promise.reject("STATUS_MESSAGE_NOT_FOUND", "Message not found.");
         } else {
-            if (overlay == true) {
+            if (overlay) {
                 Intent intent = new Intent(this.getReactApplicationContext().getCurrentActivity(), CustomLandingPageActivity.class)
                         .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
                         .setPackage(this.getReactApplicationContext().getCurrentActivity().getPackageName())
@@ -820,7 +823,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
             ReactAirshipPreferences.shared().setOptInStatus(optIn, context);
 
             Event optInEvent = new NotificationOptInEvent(optIn);
-            EventEmitter.shared().sendEvent(context, optInEvent);
+            EventEmitter.shared(context).sendEvent(optInEvent);
         }
     }
 

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -115,7 +115,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
 
         });
 
-        EventEmitter.shared(getReactApplicationContext()).attachReactContext(getReactApplicationContext());
+        EventEmitter.shared().attachReactContext(getReactApplicationContext());
     }
 
     @Override
@@ -131,7 +131,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void addAndroidListener(String eventName) {
         Logger.info("UrbanAirshipReactModule - Event listener added: " + eventName);
-        EventEmitter.shared(getReactApplicationContext()).addAndroidListener(eventName);
+        EventEmitter.shared().addAndroidListener(eventName);
     }
 
     /**
@@ -142,7 +142,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void removeAndroidListeners(int count) {
         Logger.info("UrbanAirshipReactModule - Event listeners removed: " + count);
-        EventEmitter.shared(getReactApplicationContext()).removeAndroidListeners(count);
+        EventEmitter.shared().removeAndroidListeners(count);
     }
 
     /**
@@ -823,7 +823,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
             ReactAirshipPreferences.shared().setOptInStatus(optIn, context);
 
             Event optInEvent = new NotificationOptInEvent(optIn);
-            EventEmitter.shared(context).sendEvent(optInEvent);
+            EventEmitter.shared().sendEvent(optInEvent);
         }
     }
 

--- a/android/src/main/java/com/urbanairship/reactnative/events/DeepLinkEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/DeepLinkEvent.java
@@ -40,9 +40,4 @@ public class DeepLinkEvent implements Event {
 
         return map;
     }
-
-    @Override
-    public boolean isCritical() {
-        return true;
-    }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/events/InboxUpdatedEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/InboxUpdatedEvent.java
@@ -45,9 +45,4 @@ public class InboxUpdatedEvent implements Event {
 
         return map;
     }
-
-    @Override
-    public boolean isCritical() {
-        return false;
-    }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/events/NotificationOptInEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/NotificationOptInEvent.java
@@ -42,8 +42,4 @@ public class NotificationOptInEvent implements Event {
         return map;
     }
 
-    @Override
-    public boolean isCritical() {
-        return false;
-    }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/events/NotificationResponseEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/NotificationResponseEvent.java
@@ -67,9 +67,4 @@ public class NotificationResponseEvent implements Event {
 
         return map;
     }
-
-    @Override
-    public boolean isCritical() {
-        return true;
-    }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/events/PushReceivedEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/PushReceivedEvent.java
@@ -93,12 +93,6 @@ public class PushReceivedEvent implements Event {
         return map;
     }
 
-    @Override
-    public boolean isCritical() {
-        return false;
-    }
-
-
     static String getNotificationdId(int notificationId, String notificationTag) {
         String id = String.valueOf(notificationId);
         if (!UAStringUtil.isEmpty(notificationTag)) {

--- a/android/src/main/java/com/urbanairship/reactnative/events/RegistrationEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/RegistrationEvent.java
@@ -51,9 +51,4 @@ public class RegistrationEvent implements Event {
 
         return map;
     }
-
-    @Override
-    public boolean isCritical() {
-        return false;
-    }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/events/ShowInboxEvent.java
+++ b/android/src/main/java/com/urbanairship/reactnative/events/ShowInboxEvent.java
@@ -41,9 +41,4 @@ public class ShowInboxEvent implements Event {
         map.putString(MESSAGE_ID, messageId);
         return map;
     }
-
-    @Override
-    public boolean isCritical() {
-        return true;
-    }
 }


### PR DESCRIPTION
### What do these changes do?
Fixes a bug with pending events. The pending event check was only happening when redirecting `sendEvent` to the main looper. If it was called from the main thread it would not check to make sure we have a known listener for the event. I also went ahead and did some cleanup:
- removed the `isCritical` method from events (no longer used)
- simplify the reactContext lookup by having our module attach it to the event manager. No more casting :)
- instead of doing main looper checks, just post to the main thread

### Why are these changes necessary?
Fixes pending events on Android. 

### How did you verify these changes?
Ran the sample app.
