### PR TITLE
[MOBILE-297] provide a way to enable notifications and get the auth result

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -153,6 +153,17 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * Enables user notifications.
+     *
+     * @param promise The JS promise.
+     */
+    @ReactMethod
+    public void enableUserPushNotifications(Promise promise) {
+      UAirship.shared().getPushManager().setUserNotificationsEnabled(true);
+      promise.resolve(true);
+    }
+
+    /**
      * Checks if user notifications are enabled.
      *
      * @param promise The JS promise.

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -64,6 +64,15 @@ RCT_REMAP_METHOD(isUserNotificationsOptedIn,
     resolve(@(optedIn));
 }
 
+RCT_REMAP_METHOD(enableUserPushNotifications,
+                 enableUserPushNotifications_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+
+    [[UAirship push] enableUserPushNotifications:^(BOOL success) {
+        resolve(@(success));
+    }];
+}
+
 RCT_EXPORT_METHOD(setNamedUser:(NSString *)namedUser) {
     namedUser = [namedUser stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     [UAirship namedUser].identifier = namedUser.length ? namedUser : nil;
@@ -367,7 +376,7 @@ RCT_REMAP_METHOD(displayMessage,
             [UAOverlayViewController showMessage:message];
         } else {
             UARCTMessageViewController *mvc = [[UARCTMessageViewController alloc] initWithNibName:@"UAMessageCenterMessageViewController" bundle:[UAirship resources]];
-            [mvc loadMessage:message onlyIfChanged:true];
+            [mvc loadMessageForID:message.messageID onlyIfChanged:YES onError:nil];
 
             UINavigationController *navController =  [[UINavigationController alloc] initWithRootViewController:mvc];
 

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -154,6 +154,16 @@ class UrbanAirship {
   }
 
   /**
+   * Enables user notifications.
+   *
+   * @return {Promise.<boolean>} A promise that returns true if enablement was authorized
+   * or false if enablement was rejected
+   */
+  static enableUserPushNotifications(): Promise<boolean> {
+    return UrbanAirshipModule.enableUserPushNotifications();
+  }
+
+  /**
    * Checks if app notifications are enabled or not. Its possible to have `userNotificationsEnabled`
    * but app notifications being disabled if the user opted out of notifications.
    *

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -111,6 +111,14 @@ export class UrbanAirship {
     static isUserNotificationsEnabled(): Promise<boolean>;
 
     /**
+     * Enables user push notifications.
+     *
+     * @return {Promise.<boolean>} A promise that returns true if enablement was authorized
+     * or false if enablement was rejected.
+     */
+     static enableUserPushNotifications(): Promise<boolean>
+
+    /**
      * Checks if app notifications are enabled or not. Its possible to have `userNotificationsEnabled`
      * but app notifications being disabled if the user opted out of notifications.
      *

--- a/sample/AirshipSample/ios/Podfile
+++ b/sample/AirshipSample/ios/Podfile
@@ -2,7 +2,7 @@ use_frameworks!
 project 'AirshipSample.xcodeproj'
 
 target 'AirshipSample Cocoapods' do
-platform :ios, '9.0'
+platform :ios, '10.0'
   # Required for Urban Airship
   pod 'UrbanAirship-iOS-SDK'
 end

--- a/sample/AirshipSample/ios/Podfile.lock
+++ b/sample/AirshipSample/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - UrbanAirship-iOS-AppExtensions (9.3.3)
-  - UrbanAirship-iOS-SDK (9.3.3)
+  - UrbanAirship-iOS-AppExtensions (10.0.0)
+  - UrbanAirship-iOS-SDK (10.0.0)
 
 DEPENDENCIES:
   - UrbanAirship-iOS-AppExtensions
@@ -12,9 +12,9 @@ SPEC REPOS:
     - UrbanAirship-iOS-SDK
 
 SPEC CHECKSUMS:
-  UrbanAirship-iOS-AppExtensions: fcf56299576fc30e326b560a91efaa18cc89bf83
-  UrbanAirship-iOS-SDK: 3cde24fce460c73ba1720595fab150ddce16d3ae
+  UrbanAirship-iOS-AppExtensions: b717704be3e93639229841b65075d61521ff48d0
+  UrbanAirship-iOS-SDK: 49d6f0f960f5b631af049522102fc5502111290f
 
-PODFILE CHECKSUM: 318fbed798b9ecf4971cb154cd13d6ea8c25cefe
+PODFILE CHECKSUM: d0d76b3321e154fe7bea8196de441b6d56d63efe
 
 COCOAPODS: 1.5.3

--- a/sample/scripts/run_ci_tasks.sh
+++ b/sample/scripts/run_ci_tasks.sh
@@ -8,7 +8,6 @@
 # Options:
 #   -a to run Android CI tasks.
 #   -i to run iOS CI tasks.
-#   Defaults to both.
 #####################################################
 
 set -o pipefail
@@ -29,7 +28,6 @@ while true; do
     -h  ) echo -ne "-a to run Android CI tasks.\n-i to run iOS CI tasks.\n  Defaults to both. \n"; exit 0;;
     -a  ) ANDROID=true;;
     -i  ) IOS=true;;
-    --  ) ANDROID=true; IOS=true; break;;
     *   ) break ;;
   esac
   shift


### PR DESCRIPTION
### What do these changes do?
These changes provide an interface for the newly added enableUserPushNotifications function in UAPush. This allows users to enable push with a promise that returns the auth result.

### Why are these changes necessary?
Users want to be able to enable push and receive the authorization result back immediately. 

### How did you verify these changes?
Manual testing in the sample.