### PR TITLE
[GITHUB-23] fix listener addition in UARCTEventEmitter

### DIFF
--- a/ios/UARCTModule/UARCTEventEmitter.m
+++ b/ios/UARCTModule/UARCTEventEmitter.m
@@ -72,6 +72,7 @@ static UARCTEventEmitter *sharedEventEmitter_;
 - (void)addListener:(NSString *)eventName {
     @synchronized(self.knownListeners) {
         self.listenerCount++;
+        [self.knownListeners addObject:eventName];
 
         for (id event in [self.pendingEvents copy]) {
             if ([event[UARCTEventNameKey] isEqualToString:eventName]) {
@@ -79,8 +80,6 @@ static UARCTEventEmitter *sharedEventEmitter_;
                 [self.pendingEvents removeObject:event];
             }
         }
-
-        [self.knownListeners addObject:eventName];
     }
 }
 
@@ -126,7 +125,6 @@ static UARCTEventEmitter *sharedEventEmitter_;
 
 -(void)receivedNotificationResponse:(UANotificationResponse *)notificationResponse
                   completionHandler:(void (^)(void))completionHandler {
-
     // Ignore dismisses for now
     if ([notificationResponse.actionIdentifier isEqualToString:UANotificationDismissActionIdentifier]) {
         completionHandler();


### PR DESCRIPTION
### What do these changes do?
These changes fix the issue described in issue 23:
https://github.com/urbanairship/react-native-module/issues/23

More specifically, this changes the location of the known listener addition to before the pending events are sent in the addListener method. This matches the current Android functionality

### Why are these changes necessary?
These changes are necessary to allow the notification response to result in a notification to the js-bridge.

### How did you verify these changes?
Ran the sample with and without change.