### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 2.1.1 - October 1, 2018
+=================================
+- Reverted Android firebase-core dependency back to 16.0.1 to avoid bug in 16.0.3.
+
 Version 2.1.0 - September 20, 2018
 =================================
 - Added support for enabling notifications with a resulting promise.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,5 +13,5 @@ android {
 dependencies {
     compile 'com.facebook.react:react-native:[0.40,)'
     compile 'com.urbanairship.android:urbanairship-fcm:9.5.2'
-    compile 'com.google.firebase:firebase-core:16.0.3'
+    compile 'com.google.firebase:firebase-core:16.0.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/sample/AirshipSample/package.json
+++ b/sample/AirshipSample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AirshipSample",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start"


### PR DESCRIPTION
### What do these changes do?
This reverts the android-core dependency back to 16.0.1 due to a bug outlined here:
https://github.com/invertase/react-native-firebase/issues/1051 

### Why are these changes necessary?
To resolve android build issues outlined here:
https://github.com/urbanairship/react-native-module/issues/23

### How did you verify these changes?
Ran Android sample, received push.
![image](https://user-images.githubusercontent.com/2199816/46320719-8d39b080-c594-11e8-9d5e-677ce2f83fea.png)
