### PR TITLE
use safeExtGet to get android firebase-core

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ def safeExtGet (prop, fallback) {
 dependencies {
     implementation 'com.facebook.react:react-native:[0.40,)'
     implementation 'com.urbanairship.android:urbanairship-fcm:9.5.6'
-    implementation 'com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.5')}'
+    implementation "com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.5')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,9 @@ def safeExtGet (prop, fallback) {
 
 dependencies {
     implementation 'com.facebook.react:react-native:[0.40,)'
-    implementation 'com.urbanairship.android:urbanairship-fcm:9.5.6'
+    implementation 'com.urbanairship.android:urbanairship-fcm:9.5.6' {
+      exclude group: 'com.google.firebase', module: 'firebase-messaging'
+    }
+    implementation "com.google.firebase:firebase-messaging':${safeExtGet('firebaseMessagingVersion', '17.3.4')}"
     implementation "com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.5')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,5 @@ dependencies {
       exclude group: 'com.google.firebase', module: 'firebase-messaging'
     }
     implementation "com.google.firebase:firebase-messaging':${safeExtGet('firebaseMessagingVersion', '17.3.4')}"
-    implementation "com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.5')}"
+    implementation "com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.6')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ def safeExtGet (prop, fallback) {
 dependencies {
     implementation 'com.facebook.react:react-native:[0.40,)'
     implementation 'com.urbanairship.android:urbanairship-fcm:9.5.6'
-    implementation 'com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.5'}'
+    implementation 'com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.5')}'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,6 @@ dependencies {
     implementation ('com.urbanairship.android:urbanairship-fcm:9.5.6') {
       exclude group: 'com.google.firebase', module: 'firebase-messaging'
     }
-    implementation "com.google.firebase:firebase-messaging':${safeExtGet('firebaseMessagingVersion', '17.3.4')}"
+    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '17.3.4')}"
     implementation "com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.6')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,7 @@ def safeExtGet (prop, fallback) {
 
 dependencies {
     implementation 'com.facebook.react:react-native:[0.40,)'
-    implementation 'com.urbanairship.android:urbanairship-fcm:9.5.6' {
+    implementation ('com.urbanairship.android:urbanairship-fcm:9.5.6') {
       exclude group: 'com.google.firebase', module: 'firebase-messaging'
     }
     implementation "com.google.firebase:firebase-messaging':${safeExtGet('firebaseMessagingVersion', '17.3.4')}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,8 +10,12 @@ android {
     }
 }
 
+def safeExtGet (prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 dependencies {
     implementation 'com.facebook.react:react-native:[0.40,)'
     implementation 'com.urbanairship.android:urbanairship-fcm:9.5.6'
-    implementation 'com.google.firebase:firebase-core:16.0.5'
+    implementation 'com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '16.0.5'}'
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "urbanairship-react-native-jj",
+  "name": "urbanairship-react-native",
   "version": "2.1.4",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "urbanairship-react-native",
+  "name": "urbanairship-react-native-jj",
   "version": "2.1.3",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
-  "author": "Urban Airship",
+  "author": "Urban Airship, Josh Jahans",
   "homepage": "https://github.com/urbanairship/react-native-module",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.4-alpha",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
-  "author": "Urban Airship, Josh Jahans",
+  "author": "Urban Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "2.1.4",
+  "version": "2.1.3",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native-jj",
-  "version": "2.1.4-alpha",
+  "version": "2.1.4",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native-jj",
-  "version": "2.1.3",
+  "version": "2.1.4-alpha",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship, Josh Jahans",


### PR DESCRIPTION
### What do these changes do?
Allow us to control the version of firebase core from our own projects' build.gradle files by adding a `safeExtGet` function

### Why are these changes necessary?
The fixed exact firebase version is causing conflicts with libraries that also require a fixed exact version of firebase-core

### How did you verify these changes?
In my project-level build.gradle file I add the prop `firebaseCoreVersion` and define a version:
```
ext {
    firebaseCoreVersion "+"
}
```

Or I do nothing and allow `safeExtGet` to fallback to the pre-defined version.

#### Verification Screenshots:
N/A