### PR TITLE
[MOBILE-592] add support for custom notification categories

### DIFF
--- a/ios/UARCTModule/UARCTAutopilot.m
+++ b/ios/UARCTModule/UARCTAutopilot.m
@@ -58,7 +58,18 @@ static BOOL disabled = NO;
          UA_LIMPERR(@"Current version of AirshipKit is below the recommended version. Current version: %@ Recommended version: %@", [UAirshipVersion get], UARCTAirshipKitRecommendedVersion);
     }
 
+    [self loadCustomNotificationCategories];
+}
 
++ (void)loadCustomNotificationCategories {
+    NSString *categoriesPath = [[NSBundle mainBundle] pathForResource:@"UACustomNotificationCategories" ofType:@"plist"];
+    NSSet *customNotificationCategories = [UANotificationCategories createCategoriesFromFile:categoriesPath];
+
+    if (customNotificationCategories.count) {
+        UA_LDEBUG(@"Registering custom notification categories: %@", customNotificationCategories);
+        [UAirship push].customCategories = customNotificationCategories;
+        [[UAirship push] updateRegistration];
+    }
 }
 
 @end


### PR DESCRIPTION
This adds the ability to define custom notification categories by way of plist/xml files. I followed the approach used here https://github.com/urbanairship/urbanairship-cordova/pull/228

The main difference between cordova and react here is that there's no config.xml, and instead you have add files directly to an Xcode project or save them in res/xml. Otherwise it's the same pattern. Dev supplies `ua_custom_notification_buttons.xml` and/or `UACustomNotificationCategories.plist`, the plugin looks for these files after takeOff, and if present, uses them to load custom categories or button groups.

Tested manually. Docs PR can be found here: https://github.com/urbanairship/extdocs/pull/2833