### PR TITLE
MOBILE-642 Update react plugin to iOS SDK 11.0

### DIFF
--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -136,23 +136,23 @@ RCT_REMAP_METHOD(associateIdentifier,
 }
 
 RCT_EXPORT_METHOD(setLocationEnabled:(BOOL)enabled) {
-    [UAirship location].locationUpdatesEnabled = enabled;
+    [UAirship shared].locationProviderDelegate.locationUpdatesEnabled = enabled;
 }
 
 RCT_REMAP_METHOD(isLocationEnabled,
                  isLocationEnabled_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve(@([UAirship location].isLocationUpdatesEnabled));
+    resolve(@([UAirship shared].locationProviderDelegate.isLocationUpdatesEnabled));
 }
 
 RCT_REMAP_METHOD(isBackgroundLocationAllowed,
                  isBackgroundLocationAllowed_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve(@([UAirship location].isBackgroundLocationUpdatesAllowed));
+    resolve(@([UAirship shared].locationProviderDelegate.isBackgroundLocationUpdatesAllowed));
 }
 
 RCT_EXPORT_METHOD(setBackgroundLocationAllowed:(BOOL)enabled) {
-    [UAirship location].backgroundLocationUpdatesAllowed = enabled;
+    [UAirship shared].locationProviderDelegate.backgroundLocationUpdatesAllowed = enabled;
 }
 
 RCT_REMAP_METHOD(runAction,

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -359,7 +359,7 @@ RCT_EXPORT_METHOD(dismissMessageCenter) {
 
 RCT_REMAP_METHOD(displayMessage,
                  messageId:(NSString *)messageId
-                 overlay:(BOOL *)overlay
+                 overlay:(BOOL)overlay
                  displayMessage_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
 
@@ -372,9 +372,11 @@ RCT_REMAP_METHOD(displayMessage,
 
         reject(UARCTStatusMessageNotFound, UARCTErrorDescriptionMessageNotFound, error);
     } else {
+        /*
         if (overlay) {
             [UAOverlayViewController showMessage:message];
         } else {
+        */
             UARCTMessageViewController *mvc = [[UARCTMessageViewController alloc] initWithNibName:@"UAMessageCenterMessageViewController" bundle:[UAirship resources]];
             [mvc loadMessageForID:message.messageID onlyIfChanged:YES onError:nil];
 
@@ -385,25 +387,27 @@ RCT_REMAP_METHOD(displayMessage,
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navController animated:YES completion:nil];
             });
-        }
+        //}
     }
 }
 
 RCT_REMAP_METHOD(dismissMessage,
-                 overlay:(BOOL *)overlay
+                 overlay:(BOOL)overlay
                  dismissMessage_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-
+/*
     if (overlay) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [UAOverlayViewController closeAll:YES];
         });
+ 
     } else {
+ */
         dispatch_async(dispatch_get_main_queue(), ^{
             [self.messageViewController dismissViewControllerAnimated:YES completion:nil];
             self.messageViewController = nil;
         });
-    }
+    //}
 }
 
 RCT_REMAP_METHOD(getInboxMessages,

--- a/sample/AirshipSample/ios/AirshipSample.xcodeproj/project.pbxproj
+++ b/sample/AirshipSample/ios/AirshipSample.xcodeproj/project.pbxproj
@@ -1458,7 +1458,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-AirshipSample Cocoapods/Pods-AirshipSample Cocoapods-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-AirshipSample Cocoapods/Pods-AirshipSample Cocoapods-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/UrbanAirship-iOS-SDK/AirshipKit.framework",
 				"${BUILT_PRODUCTS_DIR}/UrbanAirship-iOS-AppExtensions/AirshipAppExtensions.framework",
 			);
@@ -1469,7 +1469,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AirshipSample Cocoapods/Pods-AirshipSample Cocoapods-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AirshipSample Cocoapods/Pods-AirshipSample Cocoapods-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/sample/AirshipSample/ios/Podfile
+++ b/sample/AirshipSample/ios/Podfile
@@ -2,13 +2,13 @@ use_frameworks!
 project 'AirshipSample.xcodeproj'
 
 target 'AirshipSample Cocoapods' do
-platform :ios, '10.0'
+platform :ios, '11.0'
   # Required for Urban Airship
   pod 'UrbanAirship-iOS-SDK'
 end
 
 target 'ServiceExtension Cocoapods' do
-platform :ios, '10.0'
+platform :ios, '11.0'
   # Pods for Service Extension
   pod 'UrbanAirship-iOS-AppExtensions'
 end

--- a/sample/AirshipSample/ios/Podfile.lock
+++ b/sample/AirshipSample/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - UrbanAirship-iOS-AppExtensions (10.0.3)
-  - UrbanAirship-iOS-SDK (10.0.3)
+  - UrbanAirship-iOS-AppExtensions (11.0.0)
+  - UrbanAirship-iOS-SDK (11.0.0)
 
 DEPENDENCIES:
   - UrbanAirship-iOS-AppExtensions
@@ -12,9 +12,9 @@ SPEC REPOS:
     - UrbanAirship-iOS-SDK
 
 SPEC CHECKSUMS:
-  UrbanAirship-iOS-AppExtensions: 132efc474435d2e879c74af73365f4f2e299886c
-  UrbanAirship-iOS-SDK: 1ae7e6533a0b4798f0085eff5895a63df96efc9e
+  UrbanAirship-iOS-AppExtensions: 9f5966eaf33b8d08777addba6c5b5d27d8aacb66
+  UrbanAirship-iOS-SDK: a8d14c20a1b5af58784923b827dfd4d4145c0622
 
-PODFILE CHECKSUM: d0d76b3321e154fe7bea8196de441b6d56d63efe
+PODFILE CHECKSUM: dc7d20a967e19246d00c34a0cc36c4c944351440
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.2


### PR DESCRIPTION
There are two aspects of SDK 11.0 that required changes to the plugin. One was to get rid of old references to `[UAirship location]`. Instead of creating a whole separate plugin, this approach uses `[UAirship shared].locationProviderDelegate`, which calls through to the module (or a custom provider delegate) if present and no-ops otherwise. Since Airship dependencies are added using cocoapods, all a user has to do to enable the module is to add the AirshipLocationKit reference to their pod file. There will be other PRs in a bit that update the docs accordingly.

The other thing that needed work was methods having to do with display message center messages in overlays. We got rid of the old overlay controller in 11.0 (we hardly knew ye) and replaced it with a bridged HTML IAM. An unfortunate and unintended consequence of this is that it makes it hard-to-impossible to dismiss such a message from JS via the plugin itself, rather than the injected native bridge, and our plugin historically has a "close" method for these.

After some discussion, I picked what I thought was the least terrible short term approach, which is to set a custom adapter factory and use KVC and selectors to access the HTML view controller. It's not ideal, but it will work as a stopgap while we figure out how to do this in a cleaner way, which will almost certainly require some kind of SDK update. React users won't need to worry about this, and from their perspective it will just keep working as usual.