### PR TITLE
[MOBILE-401] add support for loading custom notification channels

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
@@ -154,7 +154,18 @@ public class ReactAutopilot extends Autopilot {
 
         airship.getPushManager().setNotificationFactory(notificationFactory);
 
+        loadCustomNotificationChannels(context, airship);
         loadCustomNotificationButtonGroups(context, airship);
+    }
+
+    private void loadCustomNotificationChannels(Context context, UAirship airship) {
+        String packageName = UAirship.shared().getPackageName();
+        @XmlRes int resId = context.getResources().getIdentifier("ua_custom_notification_channels", "xml", packageName);
+
+        if (resId != 0) {
+            Logger.debug("Loading custom notification channels");
+            airship.getPushManager().getNotificationChannelRegistry().createNotificationChannels(resId);
+        }
     }
 
     private void loadCustomNotificationButtonGroups(Context context, UAirship airship) {


### PR DESCRIPTION
Part of the update to android SDK 10 means adding support for loading custom notification channels. The most straightforward way to do that is to follow the same approach as with notification button groups and provide a mechanism for loading custom notification channels from XML, which is what this does. We will also need to provide basic documentation on how to do this and what the XML structure looks like, which will come in a subsequent extdocs PR. 