### PR TITLE
[MOBILE-644] migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,7 @@
+# Migration Guide
+
+## 2.x to 3.0.0
+
+Due to changes to the iOS SDK, location services now require an additional dependency on
+AirshipLocationKit. See the [location](https://docs.airship.com/platform/react-native/location)
+documentation for more details.


### PR DESCRIPTION
There is not much to migrate between the 2.x and 3.0 versions of our react native plugin. However, we should at least mention the change to how location is handled, and link to the appropriate section of the docs. There was no migration guide in the repo previously, so I created one.