### PR TITLE
[MOBILE-403] ReactNotificationProvider, notification config support

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
@@ -4,6 +4,7 @@ package com.urbanairship.reactnative;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.annotation.Nullable;
 
 import com.urbanairship.UAirship;
 import com.urbanairship.reactnative.events.NotificationOptInEvent;
@@ -21,6 +22,11 @@ public class ReactAirshipPreferences {
 
     private static final String NOTIFICATIONS_OPT_IN_KEY = "NOTIFICATIONS_OPT_IN_KEY";
 
+    private static final String NOTIFICATION_ICON_KEY = "notification_icon";
+    private static final String NOTIFICATION_LARGE_ICON_KEY = "notification_large_icon";
+    private static final String NOTIFICATION_ACCENT_COLOR_KEY = "notification_accent_color";
+    private static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "default_notification_channel_id";
+
     /**
      * Returns the shared {@link ReactAirshipPreferences} instance.
      *
@@ -36,6 +42,82 @@ public class ReactAirshipPreferences {
         }
 
         return preferences;
+    }
+
+    /**
+     * Sets a custom notification icon resource name.
+     * @param context The application context.
+     * @param value The value.
+     */
+    public void setNotificationIcon(Context context, @Nullable String value) {
+        getPreferences(context).edit().putString(NOTIFICATION_ICON_KEY, value).apply();
+    }
+
+    /**
+     * Gets the custom notification icon resource name.
+     * @param context The application context.
+     * @return The icon name.
+     */
+    @Nullable
+    public String getNotificationIcon(Context context) {
+        return getPreferences(context).getString(NOTIFICATION_ICON_KEY, null);
+    }
+
+    /**
+     * Sets the custom large notification icon resource name.
+     * @param context The application context.
+     * @param value The value.
+     */
+    public void setNotificationLargeIcon(Context context, @Nullable String value) {
+        getPreferences(context).edit().putString(NOTIFICATION_LARGE_ICON_KEY, value).apply();
+    }
+
+    /**
+     * Gets the custom large notification icon resource name.
+     * @param context The application context.
+     * @return The large icon name.
+     */
+    @Nullable
+    public String getNotificationLargeIcon(Context context) {
+        return getPreferences(context).getString(NOTIFICATION_LARGE_ICON_KEY, null);
+    }
+
+    /**
+     * Sets the notification accent color resource name.
+     * @param context The application context.
+     * @param value The value.
+     */
+    public void setNotificationAccentColor(Context context, @Nullable String value) {
+        getPreferences(context).edit().putString(NOTIFICATION_ACCENT_COLOR_KEY, value).apply();
+    }
+
+    /**
+     * Gets the notification accent color resource name.
+     * @param context The application context.
+     * @return The accent color.
+     */
+    @Nullable
+    public String getNotificationAccentColor(Context context) {
+        return getPreferences(context).getString(NOTIFICATION_ACCENT_COLOR_KEY, null);
+    }
+
+    /**
+     * Sets the default notification channel ID.
+     * @param context The application context.
+     * @param value The value.
+     */
+    public void setDefaultNotificationChannelId(Context context, @Nullable String value) {
+        getPreferences(context).edit().putString(DEFAULT_NOTIFICATION_CHANNEL_ID, value).apply();
+    }
+
+    /**
+     * Gets the default notification channel ID.
+     * @param context The application context.
+     * @return The default notifiation channel ID.
+     */
+    @Nullable
+    public String getDefaultNotificationChannelId(Context context) {
+        return getPreferences(context).getString(DEFAULT_NOTIFICATION_CHANNEL_ID, null);
     }
 
     /**

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
@@ -7,7 +7,6 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.XmlRes;
-import android.support.v4.app.NotificationCompat;
 
 import com.urbanairship.Autopilot;
 import com.urbanairship.Logger;
@@ -20,7 +19,6 @@ import com.urbanairship.push.NotificationListener;
 import com.urbanairship.push.PushListener;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.RegistrationListener;
-import com.urbanairship.push.notifications.DefaultNotificationFactory;
 import com.urbanairship.reactnative.events.DeepLinkEvent;
 import com.urbanairship.reactnative.events.InboxUpdatedEvent;
 import com.urbanairship.reactnative.events.NotificationResponseEvent;
@@ -136,23 +134,9 @@ public class ReactAutopilot extends Autopilot {
             }
         });
 
-
-        DefaultNotificationFactory notificationFactory = new DefaultNotificationFactory(context) {
-            @Override
-            public NotificationCompat.Builder extendBuilder(@NonNull NotificationCompat.Builder builder, @NonNull PushMessage message, int notificationId) {
-                builder.getExtras().putBundle("push_message", message.getPushBundle());
-                return builder;
-            }
-        };
-
-        if (airship.getAirshipConfigOptions().notificationIcon != 0) {
-            notificationFactory.setSmallIconId(airship.getAirshipConfigOptions().notificationIcon);
-        }
-
-        notificationFactory.setColor(airship.getAirshipConfigOptions().notificationAccentColor);
-        notificationFactory.setNotificationChannel(airship.getAirshipConfigOptions().notificationChannel);
-
-        airship.getPushManager().setNotificationFactory(notificationFactory);
+        // Set our custom notification provider
+        ReactNotificationProvider notificationProvider = new ReactNotificationProvider(context, airship.getAirshipConfigOptions());
+        airship.getPushManager().setNotificationProvider(notificationProvider);
 
         loadCustomNotificationButtonGroups(context, airship);
     }

--- a/android/src/main/java/com/urbanairship/reactnative/ReactNotificationProvider.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactNotificationProvider.java
@@ -3,100 +3,72 @@
 package com.urbanairship.reactnative;
 
 import android.content.Context;
-import android.graphics.BitmapFactory;
+import android.support.annotation.ColorInt;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.WorkerThread;
-import android.support.v4.app.NotificationCompat;
 
 import com.urbanairship.AirshipConfigOptions;
-import com.urbanairship.Logger;
-import com.urbanairship.UAirship;
-import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.notifications.AirshipNotificationProvider;
-import com.urbanairship.push.notifications.NotificationArguments;
+
 
 public class ReactNotificationProvider extends AirshipNotificationProvider {
 
+    private Context context;
+
     public ReactNotificationProvider(@NonNull Context context, @NonNull AirshipConfigOptions configOptions) {
         super(context, configOptions);
+        this.context = context;
     }
 
-    @NonNull
     @Override
-    public NotificationArguments onCreateNotificationArguments(@NonNull Context context, @NonNull PushMessage message) {
+    public String getDefaultNotificationChannelId() {
         String defaultChannelId = ReactAirshipPreferences.shared().getDefaultNotificationChannelId(context);
-
-        if (defaultChannelId == null) {
-            defaultChannelId = getDefaultNotificationChannelId();
+        if (defaultChannelId != null) {
+            return defaultChannelId;
         }
 
-        String requestedChannelId = message.getNotificationChannel(defaultChannelId);
-        String activeChannelId = getActiveChannel(requestedChannelId, DEFAULT_NOTIFICATION_CHANNEL);
-
-        return NotificationArguments.newBuilder(message)
-                .setNotificationChannelId(activeChannelId)
-                .setNotificationId(message.getNotificationTag(), getNextId(context, message))
-                .build();
+        return super.getDefaultNotificationChannelId();
     }
 
-    @WorkerThread
-    @NonNull
     @Override
-    protected NotificationCompat.Builder onExtendBuilder(@NonNull Context context,
-                                                         @NonNull NotificationCompat.Builder builder,
-                                                         @NonNull NotificationArguments arguments) {
-
-        builder.getExtras().putBundle("push_message", arguments.getMessage().getPushBundle());
-
+    @DrawableRes
+    public int getSmallIcon() {
         String iconResourceName = ReactAirshipPreferences.shared().getNotificationIcon(context);
-        String largeIconResourceName = ReactAirshipPreferences.shared().getNotificationLargeIcon(context);
-        String accentHexColor = ReactAirshipPreferences.shared().getNotificationAccentColor(context);
-
         if (iconResourceName != null) {
             int id = Utils.getNamedResource(context, iconResourceName, "drawable");
             if (id > 0) {
-                builder.setSmallIcon(id);
+                return id;
             }
         }
+
+        return super.getSmallIcon();
+    }
+
+    @Override
+    @DrawableRes
+    public int getLargeIcon() {
+        String largeIconResourceName = ReactAirshipPreferences.shared().getNotificationLargeIcon(context);
 
         if (largeIconResourceName != null) {
             int id = Utils.getNamedResource(context, largeIconResourceName, "drawable");
             if (id > 0) {
-                builder.setLargeIcon(BitmapFactory.decodeResource(context.getResources(), id));
+                return id;
             }
         }
 
-        if (accentHexColor != null) {
-            int reactColor = Utils.getHexColor(accentHexColor, getDefaultAccentColor());
-            builder.setColor(arguments.getMessage().getIconColor(reactColor));
-        }
-
-        return builder;
+        return super.getLargeIcon();
     }
 
-    /**
-     * Returns the provided channel if it exists or the default channel.
-     *
-     * @param channelId The notification channel.
-     * @param defaultChannel The default notification channel.
-     * @return The channelId if it exists, or the default channel.
-     */
-    @NonNull
-    private String getActiveChannel(@Nullable String channelId, @NonNull String defaultChannel) {
-        if (channelId == null) {
-            return defaultChannel;
+    @Override
+    @ColorInt
+    public int getDefaultAccentColor() {
+
+        String accentHexColor = ReactAirshipPreferences.shared().getNotificationAccentColor(context);
+
+        if (accentHexColor != null) {
+            return Utils.getHexColor(accentHexColor, super.getDefaultAccentColor());
         }
 
-        if (defaultChannel.equals(channelId)) {
-            return channelId;
-        }
-
-        if (UAirship.shared().getPushManager().getNotificationChannelRegistry().getNotificationChannelSync(channelId) == null) {
-            Logger.error("Notification channel %s does not exist. Falling back to %s", channelId, defaultChannel);
-            return defaultChannel;
-        }
-
-        return channelId;
+        return super.getDefaultAccentColor();
     }
 }

--- a/android/src/main/java/com/urbanairship/reactnative/ReactNotificationProvider.java
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactNotificationProvider.java
@@ -1,0 +1,65 @@
+/* Copyright Urban Airship and Contributors */
+
+package com.urbanairship.reactnative;
+
+import android.content.Context;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
+import android.support.v4.app.NotificationCompat;
+
+import com.urbanairship.AirshipConfigOptions;
+import com.urbanairship.push.notifications.AirshipNotificationProvider;
+import com.urbanairship.push.notifications.NotificationArguments;
+
+public class ReactNotificationProvider extends AirshipNotificationProvider {
+
+    private Context context;
+
+    public ReactNotificationProvider(@NonNull Context context, @NonNull AirshipConfigOptions configOptions) {
+        super(context, configOptions);
+        this.context = context;
+    }
+
+    @Override
+    @NonNull
+    public String getDefaultNotificationChannelId() {
+        String defaultChannelId = ReactAirshipPreferences.shared().getDefaultNotificationChannelId(context);
+        return defaultChannelId != null ? defaultChannelId : super.getDefaultNotificationChannelId();
+    }
+
+    @WorkerThread
+    @NonNull
+    @Override
+    protected NotificationCompat.Builder onExtendBuilder(@NonNull Context context,
+                                                         @NonNull NotificationCompat.Builder builder,
+                                                         @NonNull NotificationArguments arguments) {
+
+        builder.getExtras().putBundle("push_message", arguments.getMessage().getPushBundle());
+
+        String iconResourceName = ReactAirshipPreferences.shared().getNotificationIcon(context);
+        String largeIconResourceName = ReactAirshipPreferences.shared().getNotificationLargeIcon(context);
+        String accentHexColor = ReactAirshipPreferences.shared().getNotificationAccentColor(context);
+
+        if (iconResourceName != null) {
+            int id = Utils.getNamedResource(context, iconResourceName, "drawable");
+            if (id > 0) {
+                builder.setSmallIcon(id);
+            }
+        }
+
+        if (largeIconResourceName != null) {
+            int id = Utils.getNamedResource(context, largeIconResourceName, "drawable");
+            if (id > 0) {
+                builder.setLargeIcon(BitmapFactory.decodeResource(context.getResources(), id));
+            }
+        }
+
+        if (accentHexColor != null) {
+            builder.setColor(Utils.getHexColor(accentHexColor, Color.GRAY));
+        }
+
+        return builder;
+    }
+}

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -81,6 +81,11 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     private static final String QUIET_TIME_END_HOUR = "endHour";
     private static final String QUIET_TIME_END_MINUTE = "endMinute";
 
+    private static final String NOTIFICATION_ICON_KEY = "icon";
+    private static final String NOTIFICATION_LARGE_ICON_KEY = "largeIcon";
+    private static final String ACCENT_COLOR_KEY = "accentColor";
+    private static final String DEFAULT_CHANNEL_ID_KEY = "defaultChannelId";
+
     static final String AUTO_LAUNCH_MESSAGE_CENTER = "com.urbanairship.auto_launch_message_center";
     static final String CLOSE_MESSAGE_CENTER = "CLOSE";
 
@@ -145,6 +150,24 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     public void removeAndroidListeners(int count) {
         Logger.info("UrbanAirshipReactModule - Event listeners removed: " + count);
         EventEmitter.shared().removeAndroidListeners(count);
+    }
+
+    @ReactMethod
+    public void setAndroidNotificationConfig(ReadableMap map) {
+        Context context = getReactApplicationContext();
+        ReactAirshipPreferences prefs = ReactAirshipPreferences.shared();
+
+        prefs.setNotificationIcon(context,
+                map.hasKey(NOTIFICATION_ICON_KEY) ? map.getString(NOTIFICATION_ICON_KEY) : null);
+
+        prefs.setNotificationLargeIcon(context,
+                map.hasKey(NOTIFICATION_LARGE_ICON_KEY) ? map.getString(NOTIFICATION_LARGE_ICON_KEY) : null);
+
+        prefs.setNotificationAccentColor(context,
+                map.hasKey(ACCENT_COLOR_KEY) ? map.getString(ACCENT_COLOR_KEY) : null);
+
+        prefs.setDefaultNotificationChannelId(context,
+                map.hasKey(DEFAULT_CHANNEL_ID_KEY) ? map.getString(DEFAULT_CHANNEL_ID_KEY) : null);
     }
 
     /**

--- a/android/src/main/java/com/urbanairship/reactnative/Utils.java
+++ b/android/src/main/java/com/urbanairship/reactnative/Utils.java
@@ -1,5 +1,10 @@
 package com.urbanairship.reactnative;
 
+import android.content.Context;
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
@@ -9,10 +14,13 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.urbanairship.json.JsonMap;
 import com.urbanairship.json.JsonValue;
+import com.urbanairship.util.UAStringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import com.urbanairship.Logger;
 
 /**
  * Module utils.
@@ -67,6 +75,45 @@ class Utils {
             default:
                 return JsonValue.NULL;
         }
+    }
+
+    /**
+     * Gets a resource value by name.
+     *
+     * @param context The context.
+     * @param resourceName The resource name.
+     * @param resourceFolder The resource folder.
+     * @return The resource ID or 0 if not found.
+     */
+    public static int getNamedResource(Context context, @NonNull String resourceName, @NonNull String resourceFolder) {
+        if (!UAStringUtil.isEmpty(resourceName)) {
+            int id = context.getResources().getIdentifier(resourceName, resourceFolder, context.getPackageName());
+            if (id != 0) {
+                return id;
+            } else {
+                Logger.error("Unable to find resource with name: %s", resourceName);
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Gets a hex color as a color int.
+     *
+     * @param hexColor The hex color.
+     * @param defaultColor Default value if the conversion was not successful.
+     * @return The color int.
+     */
+    @ColorInt
+    public static int getHexColor(@NonNull String hexColor, @ColorInt int defaultColor) {
+        if (!UAStringUtil.isEmpty(hexColor)) {
+            try {
+                return Color.parseColor(hexColor);
+            } catch (IllegalArgumentException e) {
+                Logger.error( e, "Unable to parse color: %s", hexColor);
+            }
+        }
+        return defaultColor;
     }
 
 

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -138,6 +138,19 @@ export type UAEventName = $Enum<{
 class UrbanAirship {
 
   /**
+   * Sets the Android notification config. Values not set will fallback to any values set in the airship config options.
+   *
+   * @param {Object} config The notification config object.
+   * @param {string} config.icon The icon resource name.
+   * @param {string} config.largeIcon The large icon resource name.
+   * @param {string} config.accentColor The accent color in hex format (#AARRGGBB).
+   * @param {string} config.defaultChannelId The default channel ID.
+   */
+  static setAndroidNotificationConfig(config: {icon?: string, largeIcon?: string, accentColor?: string, defaultChannelId?: string }) {
+    UrbanAirshipModule.setAndroidNotificationConfig(config);
+  }
+
+  /**
    * Sets user notifications enabled. The first time user notifications are enabled
    * on iOS, it will prompt the user for notification permissions.
    *

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -98,6 +98,18 @@ declare type Listener = (response: any) => void;
  * The main Urban Airship API.
  */
 export class UrbanAirship {
+
+  /**
+   * Sets the Android notification config. Values not set will fallback to any values set in the airship config options.
+   *
+   * @param {Object} config The notification config object.
+   * @param {string} config.icon The icon resource name.
+   * @param {string} config.largeIcon The large icon resource name.
+   * @param {string} config.accentColor The accent color in hex format (#AARRGGBB).
+   * @param {string} config.defaultChannelId The default channel ID.
+   */
+  static setAndroidNotificationConfig(config: {icon?: string, largeIcon?: string, accentColor?: string, defaultChannelId?: string }) : void;
+
   /**
    * Sets user notifications enabled. The first time user notifications are enabled
    * on iOS, it will prompt the user for notification permissions.


### PR DESCRIPTION
In order to provide an interface for configuring notification options, I roughly followed the approach already in place for the cordova plugin. The difference here is mostly in the way react native bridging works, the particulars of how preferences are dealt with at the plugin level, and the fact that  NotifiationFactory has been deprecated in favor of NotificationProvider as of SDK 10.