### PR TITLE
MOBILE-702: Add support for delayed channel registration

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -181,6 +181,15 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * If `channelCreationDelayEnabled` is enabled in the config, apps must call
+     * this method to enable channel creation.
+     */
+    @ReactMethod
+    public void enableChannelCreation() {
+        UAirship.shared().getPushManager().enableChannelCreation();
+    }
+
+    /**
      * Enables user notifications.
      *
      * @param promise The JS promise.

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -52,6 +52,11 @@ RCT_EXPORT_METHOD(setUserNotificationsEnabled:(BOOL)enabled) {
     [UAirship push].userPushNotificationsEnabled = enabled;
 }
 
+
+RCT_EXPORT_METHOD(enableChannelCreation) {
+    [[UAirship push] enableChannelCreation];
+}
+
 RCT_REMAP_METHOD(isUserNotificationsEnabled,
                  isUserNotificationsEnabled_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
@@ -399,7 +404,7 @@ RCT_REMAP_METHOD(dismissMessage,
         dispatch_async(dispatch_get_main_queue(), ^{
             [self closeOverlayMessage];
         });
- 
+
     } else {
         dispatch_async(dispatch_get_main_queue(), ^{
             [self.messageViewController dismissViewControllerAnimated:YES completion:nil];

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -180,6 +180,15 @@ class UrbanAirship {
   }
 
   /**
+   * Enables channel creation if `channelCreationDelayEnabled` was
+   * enabled in the config.
+   *
+   */
+  static enableChannelCreation() {
+    UrbanAirshipModule.enableChannelCreation();
+  }
+
+  /**
    * Checks if app notifications are enabled or not. Its possible to have `userNotificationsEnabled`
    * but app notifications being disabled if the user opted out of notifications.
    *

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -134,6 +134,12 @@ export class UrbanAirship {
   static enableUserPushNotifications(): Promise<boolean>;
 
   /**
+   * Enables channel creation if `channelCreationDelayEnabled` was
+   * enabled in the config.
+   */
+  static enableChannelCreation(): void;
+
+  /**
    * Checks if app notifications are enabled or not. Its possible to have `userNotificationsEnabled`
    * but app notifications being disabled if the user opted out of notifications.
    *


### PR DESCRIPTION
### What do these changes do?
Adds support for delayed channel registration. To use delayed registration, you have to set `channelCreationDelayEnabled` to `YES`/`true` and then call `enableChannelCreation` on the push manager when you are ready to create a channel. This allows customers to delay when a billable user is created.

### Why are these changes necessary?
Customer request.

### How did you verify these changes?
Manually tested it.
