### PR TITLE
[MOBILE-809] Skip checking for message when displaying message with ID

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -42,6 +42,8 @@ import com.urbanairship.actions.OverlayRichPushMessageAction;
 import com.urbanairship.analytics.AssociatedIdentifiers;
 import com.urbanairship.app.GlobalActivityMonitor;
 import com.urbanairship.iam.html.HtmlActivity;
+import com.urbanairship.messagecenter.MessageCenter;
+import com.urbanairship.messagecenter.MessageCenterActivity;
 import com.urbanairship.push.PushMessage;
 import com.urbanairship.push.TagGroupsEditor;
 import com.urbanairship.reactnative.events.NotificationOptInEvent;
@@ -585,26 +587,18 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void displayMessage(String messageId, boolean overlay, Promise promise) {
-        RichPushMessage message = UAirship.shared().getInbox().getMessage(messageId);
-
-        if (message == null) {
-            promise.reject("STATUS_MESSAGE_NOT_FOUND", "Message not found.");
+        if (overlay) {
+            ActionRunRequest.createRequest(OverlayRichPushMessageAction.DEFAULT_REGISTRY_NAME)
+                    .setValue(messageId)
+                    .run();
         } else {
+            Intent intent = new Intent(this.getReactApplicationContext().getCurrentActivity(), CustomMessageActivity.class)
+                    .setAction(MessageCenter.VIEW_MESSAGE_INTENT_ACTION)
+                    .setPackage(this.getReactApplicationContext().getCurrentActivity().getPackageName())
+                    .setData(Uri.fromParts(MessageCenter.MESSAGE_DATA_SCHEME, messageId, null))
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
-            if (overlay) {
-                ActionRunRequest.createRequest(OverlayRichPushMessageAction.DEFAULT_REGISTRY_NAME)
-                        .setValue(messageId)
-                        .run();
-            } else {
-
-                Intent intent = new Intent(this.getReactApplicationContext().getCurrentActivity(), CustomMessageActivity.class)
-                        .setAction(RichPushInbox.VIEW_MESSAGE_INTENT_ACTION)
-                        .setPackage(this.getReactApplicationContext().getCurrentActivity().getPackageName())
-                        .setData(Uri.fromParts(RichPushInbox.MESSAGE_DATA_SCHEME, messageId, null))
-                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-
-                this.getReactApplicationContext().startActivity(intent);
-            }
+            this.getReactApplicationContext().startActivity(intent);
         }
     }
 

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -372,27 +372,19 @@ RCT_REMAP_METHOD(displayMessage,
 
     UAInboxMessage *message = [[UAirship inbox].messageList messageForID:messageId];
 
-    if (!message) {
-        NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
-                                              code:UARCTErrorCodeMessageNotFound
-                                          userInfo:@{NSLocalizedDescriptionKey:UARCTErrorDescriptionMessageNotFound}];
-
-        reject(UARCTStatusMessageNotFound, UARCTErrorDescriptionMessageNotFound, error);
+    if (overlay) {
+        [self displayOverlayMessage:messageId];
     } else {
-        if (overlay) {
-            [self displayOverlayMessage:message];
-        } else {
-            UARCTMessageViewController *mvc = [[UARCTMessageViewController alloc] initWithNibName:@"UAMessageCenterMessageViewController" bundle:[UAirship resources]];
-            [mvc loadMessageForID:message.messageID onlyIfChanged:YES onError:nil];
+        UARCTMessageViewController *mvc = [[UARCTMessageViewController alloc] initWithNibName:@"UAMessageCenterMessageViewController" bundle:[UAirship resources]];
+        [mvc loadMessageForID:messageId onlyIfChanged:YES onError:nil];
 
-            UINavigationController *navController =  [[UINavigationController alloc] initWithRootViewController:mvc];
+        UINavigationController *navController =  [[UINavigationController alloc] initWithRootViewController:mvc];
 
-            self.messageViewController = mvc;
+        self.messageViewController = mvc;
 
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navController animated:YES completion:nil];
-            });
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UIApplication sharedApplication].keyWindow.rootViewController presentViewController:navController animated:YES completion:nil];
+        });
     }
 }
 
@@ -539,7 +531,7 @@ RCT_REMAP_METHOD(getActiveNotifications,
 #pragma mark -
 #pragma mark Helper methods
 
-- (void)displayOverlayMessage:(UAInboxMessage *)message {
+- (void)displayOverlayMessage:(NSString *)messageId {
     if (!self.factoryBlockAssigned) {
         [[UAirship inAppMessageManager] setFactoryBlock:^id<UAInAppMessageAdapterProtocol> _Nonnull(UAInAppMessage * _Nonnull message) {
             UAInAppMessageHTMLAdapter *adapter = [UAInAppMessageHTMLAdapter adapterForMessage:message];
@@ -557,11 +549,8 @@ RCT_REMAP_METHOD(getActiveNotifications,
     }
 
     [UAActionRunner runActionWithName:kUAOverlayInboxMessageActionDefaultRegistryName
-                                value:message.messageID
+                                value:messageId
                             situation:UASituationManualInvocation];
-
-    // TODO: Remove this once its fixed in the SDK
-    [message markMessageReadWithCompletionHandler:nil];
 }
 
 

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -370,8 +370,6 @@ RCT_REMAP_METHOD(displayMessage,
                  displayMessage_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
 
-    UAInboxMessage *message = [[UAirship inbox].messageList messageForID:messageId];
-
     if (overlay) {
         [self displayOverlayMessage:messageId];
     } else {
@@ -379,7 +377,6 @@ RCT_REMAP_METHOD(displayMessage,
         [mvc loadMessageForID:messageId onlyIfChanged:YES onError:nil];
 
         UINavigationController *navController =  [[UINavigationController alloc] initWithRootViewController:mvc];
-
         self.messageViewController = mvc;
 
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION


### What do these changes do?
Skips the message look up with a message is being displayed from an ID. The message views know how to handle refreshing the inbox if the message is not available.

### Why are these changes necessary?
Makes the API easier to use.

### How did you verify these changes?
Manually tested both iOS and Android.
