### PR TITLE
MOBILE-897 Update React Native module to SDK 12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+Version 5.0.0 - October 16, 2019
+================================
+- Updated iOS SDK to 12.0.0
+- Updated iOS minimum deployment target to 11.0
+
 Version 4.0.2 - September 3, 2019
 =================================
 - Updated Android SDK to 11.0.4.

--- a/UrbanAirship-React-Native-Module.podspec
+++ b/UrbanAirship-React-Native-Module.podspec
@@ -13,5 +13,5 @@ require "json"
   s.source       = { :git => "https://github.com/urbanairship/react-native-module.git", :tag => "{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
   s.dependency "React"
-  s.dependency "UrbanAirship-iOS-SDK", "11.1.2"
+  s.dependency "UrbanAirship-iOS-SDK", "12.0.0"
 end

--- a/example/ios/AirshipSample.xcodeproj/project.pbxproj
+++ b/example/ios/AirshipSample.xcodeproj/project.pbxproj
@@ -231,10 +231,9 @@
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "AirshipSample" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 use_frameworks!
-platform :ios, '10.0'
+platform :ios, '11.0'
 require_relative '../../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'AirshipSample' do
@@ -36,7 +36,7 @@ target 'AirshipSample' do
 end
 
 target 'ServiceExtension' do
-  platform :ios, '10.0'
+  platform :ios, '11.0'
   # Pods for Service Extension
-  pod 'UrbanAirship-iOS-AppExtensions', '11.1.2'
+  pod 'UrbanAirship-iOS-AppExtensions', '12.0.0'
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -217,11 +217,11 @@ PODS:
     - React-cxxreact (= 0.61.1)
     - React-jsi (= 0.61.1)
     - ReactCommon/jscallinvoker (= 0.61.1)
-  - UrbanAirship-iOS-AppExtensions (11.1.2)
-  - UrbanAirship-iOS-SDK (11.1.2)
-  - UrbanAirship-React-Native-Module (4.0.2):
+  - UrbanAirship-iOS-AppExtensions (12.0.0)
+  - UrbanAirship-iOS-SDK (12.0.0)
+  - UrbanAirship-React-Native-Module (5.0.0):
     - React
-    - UrbanAirship-iOS-SDK (= 11.1.2)
+    - UrbanAirship-iOS-SDK (= 12.0.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -251,7 +251,7 @@ DEPENDENCIES:
   - React-RCTText (from `../../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../../node_modules/react-native/ReactCommon`)
-  - UrbanAirship-iOS-AppExtensions (= 11.1.2)
+  - UrbanAirship-iOS-AppExtensions (= 12.0.0)
   - UrbanAirship-React-Native-Module (from `../../.`)
   - Yoga (from `../../node_modules/react-native/ReactCommon/yoga`)
 
@@ -341,11 +341,11 @@ SPEC CHECKSUMS:
   React-RCTText: 81b62b4e7f11531a5154e4daa5617670d5a2d5de
   React-RCTVibration: 8be61459e3749d1fb02cf414edd05b3007622882
   ReactCommon: 4fba5be89efdf0b5720e0adb3d8d7edf6e532db0
-  UrbanAirship-iOS-AppExtensions: 2ce11f6072e96480b50d18d3225d9bf908781fee
-  UrbanAirship-iOS-SDK: bd236d9bc00e3c1c5e1682d8ed780d615a115811
-  UrbanAirship-React-Native-Module: e2d2e00a23307dfd01dd2debaa6ff6e3a3a6aa9d
+  UrbanAirship-iOS-AppExtensions: 881db9825b7bdb872787d6aa5b249b38bea7fa67
+  UrbanAirship-iOS-SDK: b5d24d5f1aa090e5cf827a533964d1921e400fa3
+  UrbanAirship-React-Native-Module: 0a9e217f63009eb218c82fe78519a8e9bacb3140
   Yoga: d8c572ddec8d05b7dba08e4e5f1924004a177078
 
-PODFILE CHECKSUM: f39ee7c4170d34c85837ed2387d50b87f3386d7e
+PODFILE CHECKSUM: 1a1eaeba13969ed54a7dcc7c65fe57b885e80a19
 
 COCOAPODS: 1.7.5

--- a/ios/UARCTModule/UARCTAutopilot.m
+++ b/ios/UARCTModule/UARCTAutopilot.m
@@ -6,7 +6,7 @@
 #import "UARCTMessageCenter.h"
 
 NSString *const UARCTPresentationOptionsStorageKey = @"com.urbanairship.presentation_options";
-NSString *const UARCTAirshipKitRecommendedVersion = @"11.1.1";
+NSString *const UARCTAirshipKitRecommendedVersion = @"12.0.0";
 
 @implementation UARCTAutopilot
 

--- a/ios/UARCTModule/UARCTEventEmitter.m
+++ b/ios/UARCTModule/UARCTEventEmitter.m
@@ -48,6 +48,11 @@ static UARCTEventEmitter *sharedEventEmitter_;
     if (self) {
         self.pendingEvents = [NSMutableArray array];
         self.knownListeners = [NSMutableSet set];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(channelRegistrationSucceeded:)
+                                                     name:UAChannelUpdatedEvent
+                                                   object:nil];
     }
 
     return self;
@@ -135,15 +140,21 @@ static UARCTEventEmitter *sharedEventEmitter_;
     completionHandler();
 }
 
-#pragma mark -
-#pragma mark UARegistrationDelegate
+#pragma mark Channel Registration Events
 
-- (void)registrationSucceededForChannelID:(NSString *)channelID deviceToken:(NSString *)deviceToken {
+- (void)channelRegistrationSucceeded:(NSNotification *)notification {
     NSMutableDictionary *registrationBody = [NSMutableDictionary dictionary];
+
+    NSString *channelID = notification.userInfo[UAChannelUpdatedEventChannelKey];
+    NSString *deviceToken = [UAirship push].deviceToken;
+
     [registrationBody setValue:channelID forKey:@"channelId"];
     [registrationBody setValue:deviceToken forKey:@"registrationToken"];
     [self sendEventWithName:UARCTRegistrationEventName body:registrationBody];
 }
+
+#pragma mark -
+#pragma mark UARegistrationDelegate
 
 - (void)notificationAuthorizedSettingsDidChange:(UAAuthorizedNotificationSettings)authorizedSettings {
     BOOL optedIn = NO;

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -54,7 +54,7 @@ RCT_EXPORT_METHOD(setUserNotificationsEnabled:(BOOL)enabled) {
 
 
 RCT_EXPORT_METHOD(enableChannelCreation) {
-    [[UAirship push] enableChannelCreation];
+    [[UAirship channel] enableChannelCreation];
 }
 
 RCT_REMAP_METHOD(isUserNotificationsEnabled,
@@ -94,22 +94,22 @@ RCT_REMAP_METHOD(getNamedUser,
 
 RCT_EXPORT_METHOD(addTag:(NSString *)tag) {
     if (tag) {
-        [[UAirship push] addTag:tag];
-        [[UAirship push] updateRegistration];
+        [[UAirship channel] addTag:tag];
+        [[UAirship channel] updateRegistration];
     }
 }
 
 RCT_EXPORT_METHOD(removeTag:(NSString *)tag) {
     if (tag) {
-        [[UAirship push] removeTag:tag];
-        [[UAirship push] updateRegistration];
+        [[UAirship channel] removeTag:tag];
+        [[UAirship channel] updateRegistration];
     }
 }
 
 RCT_REMAP_METHOD(getTags,
                  getTags_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve([UAirship push].tags ?: [NSArray array]);
+    resolve([UAirship channel].tags ?: [NSArray array]);
 }
 
 RCT_EXPORT_METHOD(setAnalyticsEnabled:(BOOL)enabled) {
@@ -125,7 +125,7 @@ RCT_REMAP_METHOD(isAnalyticsEnabled,
 RCT_REMAP_METHOD(getChannelId,
                  getChannelId_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve([UAirship push].channelID);
+    resolve([UAirship channel].identifier);
 }
 
 RCT_REMAP_METHOD(getRegistrationToken,
@@ -244,11 +244,11 @@ RCT_EXPORT_METHOD(editChannelTagGroups:(NSArray *)operations) {
     for (NSDictionary *operation in operations) {
         NSString *group = [operation objectForKey:@"group"];
         if ([operation[@"operationType"] isEqualToString:@"add"]) {
-            [[UAirship push] addTags:operation[@"tags"] group:group];
+            [[UAirship channel] addTags:operation[@"tags"] group:group];
         } else if ([operation[@"operationType"] isEqualToString:@"remove"]) {
-            [[UAirship push] removeTags:operation[@"tags"] group:group];
+            [[UAirship channel] removeTags:operation[@"tags"] group:group];
         } else if ([operation[@"operationType"] isEqualToString:@"set"]) {
-            [[UAirship push] setTags:operation[@"tags"] group:group];
+            [[UAirship channel] setTags:operation[@"tags"] group:group];
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Urban Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Urban Airship",

--- a/scripts/run_ci_tasks.sh
+++ b/scripts/run_ci_tasks.sh
@@ -78,7 +78,7 @@ if $ANDROID ; then
     # Build sample
     ./gradlew app:assembleDebug
 
-    cd ..
+    cd ../../
 fi
 
 # iOS
@@ -89,7 +89,7 @@ if $IOS; then
     PROJECT_PLATFORM_PATH="$(pwd)"
     DERIVED_DATA=$(mktemp -d /tmp/ci-derived-data-XXXXX)
     TARGET_SDK='iphonesimulator'
-    TEST_DESTINATION='platform=iOS Simulator,OS=latest,name=iPhone SE'
+    TEST_DESTINATION='platform=iOS Simulator,OS=latest,name=iPhone Xʀ'
 
     # install the SDK
     if [ "$BITRISE_IO" = "true" ]; then
@@ -101,7 +101,7 @@ if $IOS; then
     cp -np ${PROJECT_PLATFORM_PATH}/AirshipConfig.plist.sample ${PROJECT_PLATFORM_PATH}/AirshipConfig.plist || true
 
     # Use Debug configurations and a simulator SDK so the build process doesn't attempt to sign the output
-    xcrun xcodebuild -workspace "${PROJECT_PLATFORM_PATH}/AirshipSample.xcworkspace" -derivedDataPath "${DERIVED_DATA}" -scheme "AirshipSample Cocoapods" -configuration Debug -sdk $TARGET_SDK -destination "${TEST_DESTINATION}"
+    xcrun xcodebuild -workspace "${PROJECT_PLATFORM_PATH}/AirshipSample.xcworkspace" -derivedDataPath "${DERIVED_DATA}" -scheme "AirshipSample" -configuration Debug -sdk $TARGET_SDK -destination "${TEST_DESTINATION}"
 
     cd ..
 fi


### PR DESCRIPTION
This updates the module to use SDK 12.0, as well as fixing the inevitable deprecation warnings and some minor "recommending settings" Xcode stuff in the sample. More straightforward than the recent Cordova work, overall.

There were some things that were broken in the iOS section of the CI script that resulted in local build failures, so I went ahead and fixed those as well.