### PR TITLE
[MOBILE-958] Added the ability to turn on Autobadging in React Native

### DIFF
--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -342,6 +342,17 @@ RCT_EXPORT_METHOD(setQuietTime:(NSDictionary *)quietTime) {
     [[UAirship push] updateRegistration];
 }
 
+RCT_EXPORT_METHOD(setAutobadgeEnabled:(BOOL)enabled) {
+    [UAirship push].autobadgeEnabled = enabled;
+}
+
+RCT_REMAP_METHOD(isAutobadgeEnabled,
+                 isAutobadgeEnabled_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+
+    resolve(@([UAirship push].isAutobadgeEnabled));
+}
+
 RCT_EXPORT_METHOD(setBadgeNumber:(NSInteger)badgeNumber) {
     [[UAirship push] setBadgeNumber:badgeNumber];
 }

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -495,7 +495,7 @@ class UrbanAirship {
   }
 
   /**
-   * Sets Autobadging on iOS, either to true or false. Badging is not supported for Android.
+   * Enables or disables autobadging on iOS. Badging is not supported for Android.
    * 
    * @param {boolean} enabled Whether or not to enable Autobadging.
    */
@@ -516,7 +516,8 @@ class UrbanAirship {
     if (Platform.OS == 'ios') {
       return UrbanAirshipModule.isAutobadgeEnabled();
     } else {
-      console.log("This feature is not supported on this platform.")
+      console.log("This feature is not supported on this platform.");
+      return new Promise(resolve => resolve(false));
     }
   }
 

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -495,10 +495,10 @@ class UrbanAirship {
   }
 
   /**
-  * Sets Autobadging on iOS, either to true or false. Badging is not supported for Android.
-  * 
-  * @param {boolean} enabled Whether or not to enable Autobadging.
-  */
+   * Sets Autobadging on iOS, either to true or false. Badging is not supported for Android.
+   * 
+   * @param {boolean} enabled Whether or not to enable Autobadging.
+   */
   static setAutobadgeEnabled(enabled: boolean) {
     if (Platform.OS == 'ios') {
       UrbanAirshipModule.setAutobadgeEnabled(enabled);
@@ -513,10 +513,11 @@ class UrbanAirship {
    * @return {Promise.<boolean>} A promise with the result, either true or false.
    */
   static isAutobadgeEnabled(): Promise<boolean> {
-    if (Platform.OS != 'ios') {
+    if (Platform.OS == 'ios') {
+      return UrbanAirshipModule.isAutobadgeEnabled();
+    } else {
       console.log("This feature is not supported on this platform.")
     }
-    return UrbanAirshipModule.isAutobadgeEnabled();
   }
 
   /**

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -495,6 +495,31 @@ class UrbanAirship {
   }
 
   /**
+  * Sets Autobadging on iOS, either to true or false. Badging is not supported for Android.
+  * 
+  * @param {boolean} enabled Whether or not to enable Autobadging.
+  */
+  static setAutobadgeEnabled(enabled: boolean) {
+    if (Platform.OS == 'ios') {
+      UrbanAirshipModule.setAutobadgeEnabled(enabled);
+    } else {
+      console.log("This feature is not supported on this platform.")
+    }
+}
+
+  /**
+   * Checks to see if Autobadging on iOS is enabled. Badging is not supported for Android.
+   * 
+   * @return {Promise.<boolean>} A promise with the result, either true or false.
+   */
+  static isAutobadgeEnabled(): Promise<boolean> {
+    if (Platform.OS != 'ios') {
+      console.log("This feature is not supported on this platform.")
+    }
+    return UrbanAirshipModule.isAutobadgeEnabled();
+  }
+
+  /**
    * Sets the badge number for iOS. Badging is not supported for Android.
    *
    * @param {number} badgeNumber specified badge to set.

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -508,7 +508,7 @@ class UrbanAirship {
 }
 
   /**
-   * Checks to see if Autobadging on iOS is enabled. Badging is not supported for Android.
+   * Checks to see if autobadging on iOS is enabled. Badging is not supported for Android.
    * 
    * @return {Promise.<boolean>} A promise with the result, either true or false.
    */

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -497,7 +497,7 @@ class UrbanAirship {
   /**
    * Enables or disables autobadging on iOS. Badging is not supported for Android.
    * 
-   * @param {boolean} enabled Whether or not to enable Autobadging.
+   * @param {boolean} enabled Whether or not to enable autobadging.
    */
   static setAutobadgeEnabled(enabled: boolean) {
     if (Platform.OS == 'ios') {


### PR DESCRIPTION
https://urbanairship.atlassian.net/browse/MOBILE-958

### What do these changes do?
These changes add the ability to enable Autobadging in the React Native SDK.

### Why are these changes necessary?
Folks need a way to turn on Autobadging in this SDK just like the iOS SDK.

### How did you verify these changes?
I called the methods from App.js in the example and made sure I could return the same boolean from isAutobadgeEnabled that I set in setAutobadgeEnabled. 

To reproduce:
1. Pull this branch and switch to it
2. Somewhere in App.js (I used the constructor), call setAutobadgeEnabled and pass in true.
3. Call isAutobadgeEnbled and add .then to the end, passing in a lambda function with an argument.
```
UrbanAirship.setAutobadgeEnabled(true);
UrbanAirship.isAutobadgeEnabled().then(result => console.log(result));
```
4. Print out the result and confirm that true is the boolean value returned.
