### PR TITLE
[MOBILE-1091] make react module attributes-compatible on ios and android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,9 +15,9 @@ def safeExtGet (prop, fallback) {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation ('com.urbanairship.android:urbanairship-fcm:11.0.3') {
+    implementation ('com.urbanairship.android:urbanairship-fcm:12.0.0') {
       exclude group: 'com.google.firebase', module: 'firebase-messaging'
     }
-    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '19.0.1')}"
-    implementation "com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '17.0.1')}"
+    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.1.0')}"
+    implementation "com.google.firebase:firebase-core:${safeExtGet('firebaseCoreVersion', '17.2.1')}"
 }

--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -79,7 +79,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
 
     private static final String ATTRIBUTE_OPERATION_KEY = "key";
     private static final String ATTRIBUTE_OPERATION_VALUE = "value";
-    private static final String ATTRIBUTE_OPERATION_ACTION = "action";
+    private static final String ATTRIBUTE_OPERATION_TYPE = "action";
     private static final String ATTRIBUTE_OPERATION_SET = "set";
     private static final String ATTRIBUTE_OPERATION_REMOVE = "remove";
 
@@ -869,7 +869,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
                 continue;
             }
 
-            String action = operation.getString(ATTRIBUTE_OPERATION_ACTION);
+            String action = operation.getString(ATTRIBUTE_OPERATION_TYPE);
             String key = operation.getString(ATTRIBUTE_OPERATION_KEY);
             String value = operation.getString(ATTRIBUTE_OPERATION_VALUE);
 
@@ -880,7 +880,7 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
             if (ATTRIBUTE_OPERATION_SET.equals(action)) {
                 editor.setAttribute(key, value);
             } else if (ATTRIBUTE_OPERATION_REMOVE.equals(action)) {
-                editor.setAttribute(key, value);
+                editor.removeAttribute(key);
             }
         }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -218,10 +218,10 @@ PODS:
     - React-jsi (= 0.61.1)
     - ReactCommon/jscallinvoker (= 0.61.1)
   - UrbanAirship-iOS-AppExtensions (12.0.0)
-  - UrbanAirship-iOS-SDK (12.0.0)
-  - UrbanAirship-React-Native-Module (5.0.0):
+  - UrbanAirship-iOS-SDK (12.1.2)
+  - UrbanAirship-React-Native-Module (5.0.1):
     - React
-    - UrbanAirship-iOS-SDK (= 12.0.0)
+    - UrbanAirship-iOS-SDK (= 12.1.2)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -256,7 +256,7 @@ DEPENDENCIES:
   - Yoga (from `../../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - boost-for-react-native
     - UrbanAirship-iOS-AppExtensions
     - UrbanAirship-iOS-SDK
@@ -342,10 +342,10 @@ SPEC CHECKSUMS:
   React-RCTVibration: 8be61459e3749d1fb02cf414edd05b3007622882
   ReactCommon: 4fba5be89efdf0b5720e0adb3d8d7edf6e532db0
   UrbanAirship-iOS-AppExtensions: 881db9825b7bdb872787d6aa5b249b38bea7fa67
-  UrbanAirship-iOS-SDK: b5d24d5f1aa090e5cf827a533964d1921e400fa3
-  UrbanAirship-React-Native-Module: 0a9e217f63009eb218c82fe78519a8e9bacb3140
+  UrbanAirship-iOS-SDK: bc0d7363f62ac572211ba0191ddeac712d4d4b1f
+  UrbanAirship-React-Native-Module: 5299de6615da6a9ec05d3b1a1bc6393060df63bd
   Yoga: d8c572ddec8d05b7dba08e4e5f1924004a177078
 
 PODFILE CHECKSUM: 1a1eaeba13969ed54a7dcc7c65fe57b885e80a19
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -52,7 +52,6 @@ RCT_EXPORT_METHOD(setUserNotificationsEnabled:(BOOL)enabled) {
     [UAirship push].userPushNotificationsEnabled = enabled;
 }
 
-
 RCT_EXPORT_METHOD(enableChannelCreation) {
     [[UAirship channel] enableChannelCreation];
 }
@@ -253,6 +252,26 @@ RCT_EXPORT_METHOD(editChannelTagGroups:(NSArray *)operations) {
     }
 
     [[UAirship push] updateRegistration];
+}
+
+RCT_EXPORT_METHOD(editChannelAttributes:(NSArray *)operations) {
+    UAAttributeMutations *mutations = [UAAttributeMutations mutations];
+
+    for (NSDictionary *operation in operations) {
+        NSString *action = operation[@"action"];
+
+        // Only strings are currently supported
+        NSString *name = operation[@"key"];
+        NSString *value = operation[@"value"];
+
+        if ([action isEqualToString:@"set"]) {
+            [mutations setString:value forAttribute:name];
+        } else if ([action isEqualToString:@"remove"]) {
+            [mutations removeAttribute:name];
+        }
+    }
+
+    [[UAirship channel] applyAttributeMutations:mutations];
 }
 
 RCT_EXPORT_METHOD(setForegroundPresentationOptions:(NSDictionary *)options) {

--- a/js/AttributeEditor.js
+++ b/js/AttributeEditor.js
@@ -1,0 +1,56 @@
+// @flow
+'use strict';
+
+/** Editor for attributes. **/
+class AttributeEditor {
+  onApply: Function;
+  operations: Array;
+
+  constructor(onApply: Function) {
+      this.onApply = onApply;
+      this.operations = [];
+  }
+
+  /**
+   * Adds string attribute.
+   * @instance
+   * @memberof AttributeEditor
+   * @function setString
+   *
+   * @param {string} value The attribute value.
+   * @param {string} name The attribute name.
+   * @return {AttributeEditor} The attribute editor instance.
+   */
+  setString(value: string, name: String): AttributeEditor {
+    var operation = { "action": "set", "value": value, "key": name }
+    this.operations.push(operation)
+    return this;
+  }
+
+  /**
+   * Removes the attribute.
+   * @instance
+   * @memberof AttributeEditor
+   * @function removeAttribute
+   *
+   * @param {string} name The name of the attribute to remove.
+   * @return {AttributeEditor} The attribute editor instance.
+   */
+  removeAttribute(name: string): AttributeEditor {
+    var operation = { "action": "remove", "key": name }
+    this.operations.push(operation)
+    return this;
+  }
+
+  /**
+   * Applies the attribute operations.
+   * @instance
+   * @memberof AttributeEditor
+   * @function apply
+   */
+  apply() {
+    this.onApply(this.operations);
+  }
+}
+
+module.exports = AttributeEditor;

--- a/js/AttributeEditor.js
+++ b/js/AttributeEditor.js
@@ -21,7 +21,7 @@ class AttributeEditor {
    * @param {string} name The attribute name.
    * @return {AttributeEditor} The attribute editor instance.
    */
-  setString(value: string, name: String): AttributeEditor {
+  set(value: string, name: string): AttributeEditor {
     var operation = { "action": "set", "value": value, "key": name }
     this.operations.push(operation)
     return this;

--- a/js/AttributeEditor.js
+++ b/js/AttributeEditor.js
@@ -21,7 +21,7 @@ class AttributeEditor {
    * @param {string} name The attribute name.
    * @return {AttributeEditor} The attribute editor instance.
    */
-  set(value: string, name: string): AttributeEditor {
+  setAttribute(value: string, name: string): AttributeEditor {
     var operation = { "action": "set", "value": value, "key": name }
     this.operations.push(operation)
     return this;

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -8,6 +8,8 @@ import {
 
 import UACustomEvent from './UACustomEvent.js'
 import TagGroupEditor from './TagGroupEditor.js'
+import AttributeEditor from './AttributeEditor.js'
+
 import UAEventEmitter from './UAEventEmitter.js'
 
 const UrbanAirshipModule = NativeModules.UrbanAirshipReactModule;
@@ -266,6 +268,17 @@ class UrbanAirship {
   }
 
   /**
+   * Creates an editor to modify the channel attributes.
+   *
+   * @return {AttributeEditor} A attribute editor instance.
+   */
+  static editChannelAttributes(): AttributeEditor {
+    return new AttributeEditor((operations) => {
+      UrbanAirshipModule.editChannelAttributes(operations);
+    });
+  }
+
+  /**
    * Enables or disables analytics.
    *
    * Disabling analytics will delete any locally stored events
@@ -496,7 +509,7 @@ class UrbanAirship {
 
   /**
    * Enables or disables autobadging on iOS. Badging is not supported for Android.
-   * 
+   *
    * @param {boolean} enabled Whether or not to enable autobadging.
    */
   static setAutobadgeEnabled(enabled: boolean) {
@@ -509,7 +522,7 @@ class UrbanAirship {
 
   /**
    * Checks to see if autobadging on iOS is enabled. Badging is not supported for Android.
-   * 
+   *
    * @return {Promise.<boolean>} A promise with the result, either true or false.
    */
   static isAutobadgeEnabled(): Promise<boolean> {


### PR DESCRIPTION
### What do these changes do?
Add the ability to set attributes from react-native apps using the react-native-module.

### Why are these changes necessary?
To add attributes to iOS and Android via the react-native platfrom

### How did you verify these changes?
Manual tested on iOS and Android

#### Verification Screenshots:
Manual testing Android:
https://slack-files.com/T025Q1VP7-FR6N38N75-b79d460d92

Manual testing iOS:
![image](https://user-images.githubusercontent.com/2199816/70579761-5ed73e00-1b66-11ea-81e8-5375938ba55a.png)