### PR TITLE
[MOBILE-1268] Exposing trackScreen(screen) method

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -393,6 +393,16 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * Initiates screen tracking for a specific app screen, must be called once per tracked screen.
+     *
+     * @param {String} screen The screen's string identifier.
+     */
+    @ReactMethod
+    public void trackScreen(String screen) {
+        UAirship.shared().getAnalytics().trackScreen(screen);
+    }
+
+    /**
      * Enables/Disables location updates.
      *
      * @param enabled {@code true} to enable location updates, {@code false} to disable.

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -133,7 +133,6 @@ RCT_EXPORT_METHOD(trackScreen:(NSString *)screen) {
     [[UAirship shared].analytics trackScreen:screen]
 }
 
-
 RCT_REMAP_METHOD(getChannelId,
                  getChannelId_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {

--- a/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -129,6 +129,11 @@ RCT_REMAP_METHOD(isAnalyticsEnabled,
     resolve(@([UAirship shared].analytics.enabled));
 }
 
+RCT_EXPORT_METHOD(trackScreen:(NSString *)screen) {
+    [[UAirship shared].analytics trackScreen:screen]
+}
+
+
 RCT_REMAP_METHOD(getChannelId,
                  getChannelId_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {

--- a/js/UrbanAirship.js
+++ b/js/UrbanAirship.js
@@ -302,6 +302,15 @@ class UrbanAirship {
   }
 
   /**
+    * Initiates screen tracking for a specific app screen, must be called once per tracked screen.
+    *
+    * @param {String} screen The screen's string identifier.
+    */
+  static trackScreen(screen: string) {
+    UrbanAirshipModule.trackScreen(screen);
+  }
+
+  /**
    * Gets the channel ID.
    *
    * @return {Promise.<string>} A promise with the result.


### PR DESCRIPTION
### What do these changes do?
These changes expose the method trackScreen(screen) for the React Native Module

### Why are these changes necessary?
There was a Ticket on JIRA

### How did you verify these changes?
For Android : Quickly added in the sample app a button that call the method, then changed screen and checked that in the logs the event was correctly tracked.
For iOS : I cannot test it since I don't have a Mac yet

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->

### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->
