### PR TITLE
[MOBILE-1335] Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,30 +6,33 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-
-  android:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@master
-        with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
-      - name: Run Android CI
-        run: bash ./scripts/run_ci_tasks.sh -a
-        
-  ios:
+  build:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Run iOS CI
-        run: bash ./scripts/run_ci_tasks.sh -i
-        
-  publish_docs:
+      - name: Check Version
+        run: bash ./scripts/check_version.sh ${GITHUB_REF/refs\/tags\//}
+      - name: Slack Notification
+        uses: homoluctus/slatify@master
+        with:
+          type: ${{ job.status }}
+          job_name: "Airship React Native Release Started!"
+          url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Run CI
+        run: |
+          bash ./scripts/run_ci_tasks.sh -a -i
+      - name: Slack Notification
+        uses: homoluctus/slatify@master
+        if: failure()
+        with:
+          type: ${{ job.status }}
+          job_name: "Airship React Native Release Failed :("
+          url: ${{ secrets.SLACK_WEBHOOK }}
+
+  deploy:
+    needs: [build]
     runs-on: ubuntu-latest
-    needs: [android, ios]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -41,49 +44,28 @@ jobs:
         run: |
           npm install .
           npm run-script generate-docs
-      - name: Generate library version
-        id: lib_version
-        run: |
-         LIB_VERSION=$(cat package.json \
-         | grep version \
-         | head -1 \
-         | awk -F: '{ print $2 }' \
-         | sed 's/[",]//g' \
-         | tr -d '[[:space:]]')
-         echo ::set-output name=lib_version::${LIB_VERSION}
-      - name: Clone mobile-docs repository and add documentation
-        run: |
-         git clone "https://${{ secrets.GitHub_PAT }}@github.com/urbanairship/mobile-docs.git"
-         cd mobile-docs
-         bash add.sh react-native ../out ${{ steps.lib_version.outputs.lib_version }}
-      - name: Commit documentation
-        run: |
-         git add .
-         git commit -a -m "Added docs for react-native v${LIB_VERSION}"
-         git push origin master
-        
-  publish:
-    runs-on: ubuntu-latest
-    needs: [android, ios, publish_docs]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@master
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
+          version: "270.0.0"
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Upload docs
+        run: bash ./scripts/upload_docs.sh ${GITHUB_REF/refs\/tags\//} out
       - name: Publish library
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-        
-  finished:
-    runs-on: ubuntu-latest
-    needs: [android, ios, publish_docs, publish]
-    steps:
       - name: Slack Notification
         uses: homoluctus/slatify@master
-        if: always()
+        if: success()
         with:
           type: ${{ job.status }}
-          job_name: ":raised_hands: Airship React native Plugin Released! :raised_hands:"
+          job_name: "Airship React native Plugin Released!"
           url: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
+      - name: Slack Notification
+        uses: homoluctus/slatify@master
+        if: failure()
+        with:
+          type: ${{ job.status }}
+          job_name: "Airship React Native Release Failed :("
+          url: ${{ secrets.SLACK_WEBHOOK }}

--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -x
+
+ROOT_PATH=`dirname "${0}"`/..
+
+VERSION=$(node -p "require('$ROOT_PATH/package.json').version")
+
+if [ $1 = $VERSION ]; then
+ exit 0
+else
+ exit 1
+fi

--- a/scripts/upload_docs.sh
+++ b/scripts/upload_docs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+set -e
+set -x
+
+if [ -z "$1" ]
+  then
+    echo "No version supplied"
+    exit 1
+fi
+
+if [ ! -d "$2" ]; then
+then
+    echo "Missing docs $2"
+    exit 1
+fi
+
+ROOT_PATH=`dirname "${0}"`/..
+TAR_NAME="$1.tar.gz"
+
+cd out
+tar -czf $TAR_NAME *
+cd -
+
+gsutil cp $ROOT_PATH/out/$TAR_NAME gs://ua-web-ci-prod-docs-transfer/libraries/react-native/$TAR_NAME


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
<!-- ℹ Please provide a description of your changes here. -->

Uploads docs to GCS instead of mobile, adds a version check on the tag, and simplifies the release flow to be two parts (build/ci vs publish)

### Why are these changes necessary?
We want to remove the use of the mobile-docs repo
