### PR TITLE
[MOBILE-1336] update to 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+
+Version 6.1.1 - February 25, 2020
+=================================
+Patch release enabling monorepo project structure. 
+Example app dependencies have been moved from the module's 
+package.json to the example app. These include:
+
+- react-native-gesture-handler
+- react-native-reanimated
+- react-native-screens
+- react-navigation
+- react-navigation-tabs
+
+iOS and Android SDKs remain at 13.1.0 and 12.2.0, respectively.
+
 Version 6.1.0 - February 21, 2020
 =================================
 - Updated iOS SDK to 13.1.0

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -30,7 +30,7 @@ yarn install
 
 3) Create the `AirshipConfig.plist` file
 
-4) Start the webserver in the `example` directory by running `yarn react-native start`
+4) Start the webserver in the top-level directory by running `yarn start`
 
 5) Build and run the sample in the `example` directory: `yarn run:ios`
 
@@ -45,7 +45,7 @@ directly in the sample's workspace.
 
 3) If using FCM, add your `google-services.json` file in `example/android/app`
 
-4) Start the webserver in the `example` directory by running `yarn react-native start`
+4) Start the webserver in the top-level directory by running `yarn start`
 
 5) Build and run the sample in the `example` directory: `yarn run:android`
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -236,7 +236,7 @@ PODS:
     - React
   - RNScreens (2.0.0-beta.12):
     - React
-  - urbanairship-react-native (6.1.0):
+  - urbanairship-react-native (6.1.1):
     - Airship (= 13.1.0)
     - React
   - Yoga (1.14.0)
@@ -372,7 +372,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: dde546180bf24af0b5f737c8ad04b6f3fa51609a
   RNReanimated: 031fe8d9ea93c2bd689a40f05320ef9d96f74d7f
   RNScreens: 5462aa9a2b2cdf23d81d3f4ac2cf9bb54f27f594
-  urbanairship-react-native: e87a5bbb77a95f9dd11e9f7ed598b08c563dedb9
+  urbanairship-react-native: 7e800d6a410791ed2a2cb5c58a3fe5d0ce79aa2e
   Yoga: d8c572ddec8d05b7dba08e4e5f1924004a177078
 
 PODFILE CHECKSUM: 3b1e496b3d7771c6b9bf243d65fe1c555613c117

--- a/example/package.json
+++ b/example/package.json
@@ -13,9 +13,7 @@
       "urbanairship-react-native": "*"
     },
     "scripts": {
-      "start": "react-native start",
       "run:android": "react-native run-android",
-      "run:ios": "react-native run-ios",
-      "cli-version" : "react-native --version"
+      "run:ios": "react-native run-ios"
     }
  }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preset": "react-native"
   },
   "scripts": {
+    "start": "react-native start",
     "generate-docs": "node_modules/.bin/documentation --config documentation.yml build src/js/** -f html -o out",
     "test": "jest --verbose",
     "clean": "rm -rf node_modules src/node_modules example/node_modules yarn.lock"

--- a/src/ios/UARCTModule/UARCTModuleVersion.m
+++ b/src/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const moduleVersionString = @"6.1.0";
+NSString *const moduleVersionString = @"6.1.1";
 
 + (nonnull NSString *)get {
     return moduleVersionString;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Airship plugin for React Native apps.",
   "main": "./js/index.js",
   "author": "Airship",


### PR DESCRIPTION
Pretty self explanatory. This patch is mostly just to get rid of the unnecessary dependencies for the module, but it's also an opportunity to validate the new monorepo structure. I made a few edits to the dev readme and the scripts, as I discovered that the workspace structure we ended up with requires that you start metro from the repo root. There was also a cli-version script I had added, but that I don't think adds much value. If you're ever curious what version of the cli tools you have, just run `yarn react-native --version`.