### PR TITLE
[MOBILE-831] add typescript definitions for UAMessageView

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -75,6 +75,85 @@ declare class TagGroupEditor {
   apply(): void;
 }
 
+/**
+ * Event type indicating that a message load has started.
+ */
+declare interface MessageLoadStartedEvent {
+  /**
+   * The message ID.
+   */
+  messageId: string;
+}
+
+/**
+ * Event type indicating that a message load finished.
+ */
+declare interface MessageLoadFinishedEvent {
+  /**
+   * The message ID.
+   */
+  messageId: string;
+}
+
+/**
+ * Event type indicating that a message load failed.
+ */
+declare interface MessageLoadErrorEvent {
+  /**
+   * The message ID.
+   */
+  messageId: string;
+  /**
+   * The error message.
+   */
+  error: string;
+  /**
+   * Whether the error is retriable.
+   */
+  retryable: boolean;
+}
+
+/**
+ * Event type indicating that message was closed.
+ */
+declare interface MessageCloseEvent {
+  /**
+   * The message ID.
+   */
+  messageId:string;
+}
+
+/**
+ * Properties for UAMessageView.
+ */
+declare interface MessageViewProps {
+  /**
+   * The message ID to load.
+   */
+  messageId: string;
+  /**
+   * Callback invoked when loading starts.
+   */
+  onLoadStarted?: (event: MessageLoadStartedEvent) => void;
+  /**
+   * Callback invoked when loading finishes.
+   */
+  onLoadFinished?: (event: MessageLoadFinishedEvent) => void;
+  /**
+   * Callback invoked when loading fails.
+   */
+  onLoadError?: (event: MessageLoadErrorEvent) => void;
+  /**
+   * Callback invoked when the message is closed.
+   */
+  onClose?: (event: MessageCloseEvent) => void;
+}
+
+/**
+ * Component class for loading and displaying Message Center messages.
+ */
+declare class UAMessageView extends React.Component<MessageViewProps, any> {}
+
 declare interface Message {
   /** The messages ID.Needed to display, mark as read, or delete the message. **/
   id: string;


### PR DESCRIPTION
This PR adds typescript definitions for ourUAMessageView, including typed interfaces for the properties and callback events. This makes it possible to instantiate a UAWebView like this:

```
<UAMessageView
    style={{
        height: 200,
    }}
    messageId="haha-not-a-real-message-YMMV"
    onLoadStarted={(event: MessageLoadStartedEvent) => {
        console.log("cool: " + event.messageId)
    }}
    onLoadError={(event: MessageLoadErrorEvent) => {
        console.log("not cool: " + event.error)
    }}>
</UAMessageView>
```
Here is a screenshot of the typescript app I hacked together to test it out:

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-28 at 15 23 21](https://user-images.githubusercontent.com/545958/75595589-dcae3580-5a41-11ea-9313-905c9c64cd78.png)
 
We could stand to have better means of testing typescript stuff, so I'll probably be making a ticket or two to devote more time to creating a proper typescript example that we can continue to use going forward. It's a bit tricky with the new monorepo situation, so I don't want to go too far down the rabbit hole just yet.

