### PR TITLE
[acorn-security-fix] update acorn to 7.1.1

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -19,7 +19,7 @@
     "@babel/runtime": "7.5.4",
     "@react-native-community/eslint-config": "0.0.5",
     "@typescript-eslint/parser": "^1.13.0",
-    "acorn": "^7.0.0",
+    "acorn": "^7.1.1",
     "acorn-jsx": "^5.0.2",
     "documentation": "12.1.1",
     "eslint": "^5.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,10 +1602,10 @@ acorn@^6.0.1, acorn@^6.0.7:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
   integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
-acorn@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
-  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+acorn@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
 ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
   version "6.12.0"


### PR DESCRIPTION
There's a security vulnerability in acorn that was recently patched in 7.1.1.

https://snyk.io/vuln/SNYK-JS-ACORN-559469

We were originally notified by a Github bot, which automatically opened a PR of its own. Acorn is only a dev dependency, so this doesn't require republishing the plugin. I've manually verified that all the tooling still works properly.