### PR TITLE
[MOBILE-978] Remove use of synchronize method

### DIFF
--- a/src/ios/UARCTModule/UARCTAutopilot.m
+++ b/src/ios/UARCTModule/UARCTAutopilot.m
@@ -54,7 +54,6 @@ static BOOL disabled = NO;
 
     if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTAutoLaunchMessageCenterKey] == nil) {
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:UARCTAutoLaunchMessageCenterKey];
-        [[NSUserDefaults standardUserDefaults] synchronize];
     }
 
     if (([UARCTAirshipRecommendedVersion compare:[UAirshipVersion get] options:NSNumericSearch] == NSOrderedDescending)) {

--- a/src/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/src/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -536,7 +536,6 @@ RCT_REMAP_METHOD(refreshInbox,
 
 RCT_EXPORT_METHOD(setAutoLaunchDefaultMessageCenter:(BOOL)enabled) {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:UARCTAutoLaunchMessageCenterKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 RCT_EXPORT_METHOD(clearNotifications) {


### PR DESCRIPTION
### What do these changes do?
Remove [[NSUserDefaults standardUserDefaults] synchronize]. Apple recommends not using this method anymore 

