### PR TITLE
Add missing React import in TS definition

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { EmitterSubscription } from "react-native";
 
 declare type JsonValue = string | number | boolean | null | JsonMap | JsonArray;


### PR DESCRIPTION
### What do these changes do?
Typescript definition file declares such component:
`UAMessageView extends React.Component`
but `React` type is not imported. Added it.

### Why are these changes necessary?
Missing import causes an error for Typescript compiler.

### How did you verify these changes?
Typescript compiler passes correctly.

#### Verification Screenshots:
No need.

### Anything else a reviewer should know?
Would be nice to e.g. add a CI step to ensure that TS definition is valid in the future.
