### PR TITLE
[MOBILE-1729] fix exports for accengage, location, hms modules

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
     "@react-native-community/masked-view": "^0.1.7",
     "moment": "^2.24.0",
     "react": "16.10.1",
-    "react-native": "0.61.1",
+    "react-native": "0.61.5",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-reanimated": "^1.7.1",
     "react-native-safe-area-context": "^0.7.3",

--- a/urbanairship-accengage-react-native/js/index.ts
+++ b/urbanairship-accengage-react-native/js/index.ts
@@ -6,6 +6,4 @@
  * React Native module for Urban Airship.
  * @module react-native-airship-accengage
  */
-import { NativeModules } from 'react-native';
 
-const { AirshipAccengage } = NativeModules;

--- a/urbanairship-hms-react-native/js/index.ts
+++ b/urbanairship-hms-react-native/js/index.ts
@@ -6,9 +6,3 @@
  * React Native module for Urban Airship.
  * @module react-native-airship-accengage
  */
-
-import { NativeModules } from 'react-native';
-
-const { AirshipHMS } = NativeModules;
-
-export default AirshipHMS;

--- a/urbanairship-location-react-native/ios/AirshipLocation.h
+++ b/urbanairship-location-react-native/ios/AirshipLocation.h
@@ -1,5 +1,0 @@
-#import <React/RCTBridgeModule.h>
-
-@interface AirshipLocation : NSObject <RCTBridgeModule>
-
-@end

--- a/urbanairship-location-react-native/ios/AirshipLocation.m
+++ b/urbanairship-location-react-native/ios/AirshipLocation.m
@@ -1,7 +1,0 @@
-#import "AirshipLocation.h"
-
-@implementation AirshipLocation
-
-RCT_EXPORT_MODULE()
-
-@end

--- a/urbanairship-location-react-native/ios/AirshipLocation.xcodeproj/project.pbxproj
+++ b/urbanairship-location-react-native/ios/AirshipLocation.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1B0269042498C8A600B91120 /* AirshipLocationReactModuleVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B0269022498C8A600B91120 /* AirshipLocationReactModuleVersion.m */; };
-		1B0269072498C8B600B91120 /* AirshipLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B0269052498C8B600B91120 /* AirshipLocation.m */; };
 		1B02690D249B8E2700B91120 /* AirshipLocationReactModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B02690C249B8E2700B91120 /* AirshipLocationReactModule.m */; };
 /* End PBXBuildFile section */
 
@@ -28,8 +27,6 @@
 		1B0268F62498C72A00B91120 /* libAirshipLocation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAirshipLocation.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B0269022498C8A600B91120 /* AirshipLocationReactModuleVersion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AirshipLocationReactModuleVersion.m; sourceTree = "<group>"; };
 		1B0269032498C8A600B91120 /* AirshipLocationReactModuleVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AirshipLocationReactModuleVersion.h; sourceTree = "<group>"; };
-		1B0269052498C8B600B91120 /* AirshipLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AirshipLocation.m; sourceTree = "<group>"; };
-		1B0269062498C8B600B91120 /* AirshipLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AirshipLocation.h; sourceTree = "<group>"; };
 		1B02690B249B8E2700B91120 /* AirshipLocationReactModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AirshipLocationReactModule.h; sourceTree = "<group>"; };
 		1B02690C249B8E2700B91120 /* AirshipLocationReactModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AirshipLocationReactModule.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -50,8 +47,6 @@
 			children = (
 				1B02690B249B8E2700B91120 /* AirshipLocationReactModule.h */,
 				1B02690C249B8E2700B91120 /* AirshipLocationReactModule.m */,
-				1B0269062498C8B600B91120 /* AirshipLocation.h */,
-				1B0269052498C8B600B91120 /* AirshipLocation.m */,
 				1B0269032498C8A600B91120 /* AirshipLocationReactModuleVersion.h */,
 				1B0269022498C8A600B91120 /* AirshipLocationReactModuleVersion.m */,
 				1B0268F72498C72A00B91120 /* Products */,
@@ -151,7 +146,6 @@
 			files = (
 				1B0269042498C8A600B91120 /* AirshipLocationReactModuleVersion.m in Sources */,
 				1B02690D249B8E2700B91120 /* AirshipLocationReactModule.m in Sources */,
-				1B0269072498C8B600B91120 /* AirshipLocation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/urbanairship-location-react-native/ios/AirshipLocationReactModule.m
+++ b/urbanairship-location-react-native/ios/AirshipLocationReactModule.m
@@ -5,6 +5,11 @@
 @implementation AirshipLocationReactModule
 
 #pragma mark -
+#pragma mark Module setup
+
+RCT_EXPORT_MODULE();
+
+#pragma mark -
 #pragma mark Module methods
 
 RCT_EXPORT_METHOD(setLocationEnabled:(BOOL)enabled) {


### PR DESCRIPTION
The accengage and HMS modules don't need to export anything in JS because they're just adding frameworks to the native build, and don't have anything to export. On iOS the location module was calling RCT_EXPORT_MODULE  from an empty class file, which was confusing React Native at runtime, with messages like "do you need to call RCT_EXPORT_MODULE?". I tested that the HMS module still gets loaded natively without anything being imported on the JS side, and that the location module is works on iOS as expected. Also bumped the version in the example, since we're now targeting 0.61.5.