### PR TITLE
[MOBILE 1797] Edited removeListener desciption, added removeAllListeners and removeSubscription methods

### DIFF
--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -653,7 +653,7 @@ export class UrbanAirship {
    * EventType.InboxUpdated, or EventType.ShowInbox.
    */
   static removeAllListeners(eventType: EventType) {
-    EventEmitter.removeAllListeners(eventType);
+    EventEmitter.removeAllListeners(convertEventEnum(eventType));
   }
 
   /**

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -639,7 +639,7 @@ export class UrbanAirship {
   /**
    * Removes a listener for an Urban Airship event.
    *
-   * @param listener The event listner (also an emitter subscription).
+   * @param listener The event listener (an emitter subscription).
    */
   static removeListener(listener: EmitterSubscription) {
     EventEmitter.removeSubscription(listener);

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -629,7 +629,7 @@ export class UrbanAirship {
    * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,
    * EventType.Register, EventType.Reistration, EventType.DeepLink, EventType.NotificationOptInStatus,
    * EventType.InboxUpdated, or EventType.ShowInbox.
-   * @param listener The event listner.
+   * @param listener The event listener.
    * @return An emitter subscription.
    */
   static addListener(eventType: EventType, listener: (...args: any[]) => any): EmitterSubscription {
@@ -642,7 +642,7 @@ export class UrbanAirship {
    * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,
    * EventType.Register, EventType.Reistration, EventType.DeepLink, EventType.NotificationOptInStatus,
    * EventType.InboxUpdated, or EventType.ShowInbox.
-   * @param listener The event listner. Should be a reference to the function passed into addListener.
+   * @param listener The event listener. Should be a reference to the function passed into addListener.
    */
   static removeListener(eventType: EventType, listener: (...args: any[]) => any) {
     EventEmitter.removeListener(convertEventEnum(eventType), listener);

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -636,13 +636,25 @@ export class UrbanAirship {
     return EventEmitter.addListener(convertEventEnum(eventType), listener);
   }
 
-  /**
+   /**
    * Removes a listener for an Urban Airship event.
    *
-   * @param listener The event listener (an emitter subscription).
+   * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,
+   * EventType.Register, EventType.Reistration, EventType.DeepLink, EventType.NotificationOptInStatus,
+   * EventType.InboxUpdated, or EventType.ShowInbox.
+   * @param listener The event listner. Should be a reference to the function passed into addListener.
    */
-  static removeListener(listener: EmitterSubscription) {
-    EventEmitter.removeSubscription(listener);
+  static removeListener(eventType: EventType, listener: (...args: any[]) => any) {
+    EventEmitter.removeListener(convertEventEnum(eventType), listener);
+  }
+
+  /**
+   * Removes a subscription for an Urban Airship event.
+   *
+   * @param subscription The emitter subscription, returned from addListener.
+   */
+  static removeSubscription(subscription: EmitterSubscription) {
+    EventEmitter.removeSubscription(subscription);
   }
 
   /**

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -626,7 +626,7 @@ export class UrbanAirship {
   /**
    * Adds a listener for an Urban Airship event.
    *
-   * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,
+   * @param eventType The event type. Either EventType.NotificationResponse, EventType.PushReceived,
    * EventType.Register, EventType.Reistration, EventType.DeepLink, EventType.NotificationOptInStatus,
    * EventType.InboxUpdated, or EventType.ShowInbox.
    * @param listener The event listener.
@@ -639,7 +639,7 @@ export class UrbanAirship {
   /**
    * Removes a listener for an Urban Airship event.
    *
-   * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,
+   * @param eventType The event type. Either EventType.NotificationResponse, EventType.PushReceived,
    * EventType.Register, EventType.Reistration, EventType.DeepLink, EventType.NotificationOptInStatus,
    * EventType.InboxUpdated, or EventType.ShowInbox.
    * @param listener The event listener. Should be a reference to the function passed into addListener.
@@ -651,7 +651,7 @@ export class UrbanAirship {
   /**
    * Removes all listeners for Urban Airship events.
    *
-   * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,
+   * @param eventType The event type. Either EventType.NotificationResponse, EventType.PushReceived,
    * EventType.Register, EventType.Reistration, EventType.DeepLink, EventType.NotificationOptInStatus,
    * EventType.InboxUpdated, or EventType.ShowInbox.
    */
@@ -817,7 +817,7 @@ export class UrbanAirship {
    * Supported on Android and iOS 10+.
    *
    * @param identifier The notification identifier. The identifier will be
-   * available in the pushReceived event and in the active notification response
+   * available in the PushReceived event and in the active notification response
    * under the "notificationId" field.
    */
   static clearNotification(identifier: string) {

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -636,7 +636,7 @@ export class UrbanAirship {
     return EventEmitter.addListener(convertEventEnum(eventType), listener);
   }
 
-   /**
+  /**
    * Removes a listener for an Urban Airship event.
    *
    * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -639,13 +639,21 @@ export class UrbanAirship {
   /**
    * Removes a listener for an Urban Airship event.
    *
+   * @param listener The event listner (also an emitter subscription).
+   */
+  static removeListener(listener: EmitterSubscription) {
+    EventEmitter.removeSubscription(listener);
+  }
+
+  /**
+   * Removes all listeners for Urban Airship events.
+   *
    * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,
    * EventType.Register, EventType.Reistration, EventType.DeepLink, EventType.NotificationOptInStatus,
    * EventType.InboxUpdated, or EventType.ShowInbox.
-   * @param listener The event listner.
    */
-  static removeListener(eventType: EventType, listener: (...args: any[]) => any) {
-    EventEmitter.removeListener(convertEventEnum(eventType), listener);
+  static removeAllListeners(eventType: EventType) {
+    EventEmitter.removeAllListeners(eventType);
   }
 
   /**

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -649,15 +649,6 @@ export class UrbanAirship {
   }
 
   /**
-   * Removes a subscription for an Urban Airship event.
-   *
-   * @param subscription The emitter subscription, returned from addListener.
-   */
-  static removeSubscription(subscription: EmitterSubscription) {
-    EventEmitter.removeSubscription(subscription);
-  }
-
-  /**
    * Removes all listeners for Urban Airship events.
    *
    * @param eventType The event type. Either EventType.NotificationResponse, EventType.pushReceived,


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
These changes change the `removeListener` method so that it takes an Event Emitter subscription to pass onto `removeSubscription` in `UAEventEmitter.ts`, which should remove the listener. I also added UAEventEmitter's `removeAllListeners` to `UrbanAirship.ts` as it wasn't previously in there, and should let users remove all event listeners of a certain type if they so choose.

### Why are these changes necessary?
`removeListener` doesn't work in its current state. I believe it's supposed to be inherited from React Native itself, but no combination of parameters actually seem to remove the listener (I've tried passing the event type as the first argument, and the emitter subscription as the second argument). From [this stack overflow question](https://stackoverflow.com/questions/36886628/how-do-you-remove-a-listener-from-react-natives-eventemitter-instance/36901160), it does seem that the best way to remove a listener is by removing the emitter through `removeSubscription`. As for why the react native removeListener doesn't work, I'm really not quite sure. Maybe it doesn't know what individual listener to remove by the event type?

As for adding `removeAllListeners`, this was already in `UAEventEmitter`, but wasn't being used, so I added it.

### How did you verify these changes?
To verify, I made the changes in the react-native-module, and installed that to my react native project and created buttons calling the methods in UrbanAirship.ts to add a listener, remove a listener, and remove all listeners.

1. Pull this branch
2. `npm link`, then `npm pack` in react-native-module
3. `npm install <tarball created from npm pack>`
4. In your test app, add some event listeners (can be any type, though I mainly tested with deep link).
5. Call `removeAllListeners`, all event listeners should be removed.
6. Add some more event listeners, and make sure to store the emitter subscription returned from `addListener`.
7. Call `removeListener` passing in emitter subscription.

### Anything else a reviewer should know?
Let me know if you guys think this is the right approach, I want to make sure it works with what y'all have planned for the react native library.

## EDIT

After talking with Marc, it was determined that the `removeListener` method was working correctly, though is rather confusing to use. The second parameter expects a reference to the original listener function, which many devs wouldn't think to create before passing it into `addListener`. Because of that, I've edited the description of `addListener` to make that a bit more clear.

Also, I think its still beneficial to add `addSubscription` and `removeAllListeners`, so I've gone ahead and done that as well.