### PR TITLE
[MOBILE-1953] fix iOS foreground presentation options

### DIFF
--- a/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.m
@@ -46,9 +46,8 @@ static BOOL disabled = NO;
                                              name:UAInboxMessageListUpdatedNotification
                                            object:nil];
 
-    UNNotificationPresentationOptions presentationOptions = (UNNotificationPresentationOptions)[[NSUserDefaults standardUserDefaults] valueForKey:UARCTPresentationOptionsStorageKey];
-
-    if (presentationOptions) {
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTPresentationOptionsStorageKey]) {
+        UNNotificationPresentationOptions presentationOptions = [[NSUserDefaults standardUserDefaults] integerForKey:UARCTPresentationOptionsStorageKey];
         [[UAirship push] setDefaultPresentationOptions:presentationOptions];
     }
 


### PR DESCRIPTION
We were pulling presentation options in UARCTAutopilot using the KVC `valueForKey:` method instead of `integerForKey`. Casting this to an integer produces an integer of the backing object pointer, not the options integer its elf. As a result, any previously set foreground presentation options were getting overwritten with garbage during autopilot takeOff. This fixes the issue by checking to see if a value is actually stored in NSUserDefaults and if so, retrieving it using the correct method.

Tested manually on a device with foreground push notifications. 