### PR TITLE
Release 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # React Native Module Changelog
 
+## Version 10.0.0 - December 18, 2020
+
+Major release that updates the iOS Airship SDK to 14.2.0 and the Android SDK to 14.1.0. Xcode 12 is required for this version.
+
+- Added better logging for default presentation options
+- Changed InboxMessage.extras type from Map<string, string> to Record<string, string>
+- Updated Android SDK to 14.1.0
+- Updated iOS SDK to 14.2.0
+- Fixed Xcode 12 compatibility
+- firebaseMessagingVersion requires version 21.0.0+
+
 ## Version 9.0.1 - October 22, 2020
 Patch release that updates the iOS and Android SDKs to 14.0.1, and fixes
-a bug impacting foreground noitification options on iOS. 
+a bug impacting foreground noitification options on iOS.
 
 - Updated Android SDK to 14.0.1
 - Updated iOS SDK to 14.0.1

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A React Native module for Airship's iOS and Android SDK.
 Please visit https://support.airship.com/ for any issues integrating or using this module.
 
 ### Requirements:
- - Xcode 11+
+ - Xcode 12+
  - iOS: Deployment target 11.0+
- - Android: minSdkVersion 16+, compileSdkVersion 28+
+ - Android: minSdkVersion 16+, compileSdkVersion 29+
  - React Native >= 0.60.0
  - React Native cli >= 2.0.1
 
@@ -113,10 +113,7 @@ Firebase core and messaging dependencies versions can be overriden by setting th
 
 ```
 ext {
-    // Requires 17.0.0+
-    firebaseCoreVersion "VERSION"
-
-    // Requires 19.0.0+
+    // Requires 21.0.0+
     firebaseMessagingVersion "VERSION"
 }
 ```

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -14,5 +14,5 @@ end
 target 'ServiceExtension' do
   platform :ios, '11.0'
   # Pods for Service Extension
-  pod 'AirshipExtensions/NotificationService', '~> 14.1.3'
+  pod 'AirshipExtensions/NotificationService', '~> 14.2.0'
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Airship (14.1.3):
-    - Airship/Automation (= 14.1.3)
-    - Airship/Core (= 14.1.3)
-    - Airship/ExtendedActions (= 14.1.3)
-    - Airship/MessageCenter (= 14.1.3)
-  - Airship/Accengage (14.1.3):
+  - Airship (14.2.0):
+    - Airship/Automation (= 14.2.0)
+    - Airship/Core (= 14.2.0)
+    - Airship/ExtendedActions (= 14.2.0)
+    - Airship/MessageCenter (= 14.2.0)
+  - Airship/Accengage (14.2.0):
     - Airship/Core
-  - Airship/Automation (14.1.3):
+  - Airship/Automation (14.2.0):
     - Airship/Core
-  - Airship/Core (14.1.3)
-  - Airship/ExtendedActions (14.1.3):
+  - Airship/Core (14.2.0)
+  - Airship/ExtendedActions (14.2.0):
     - Airship/Core
-  - Airship/Location (14.1.3):
+  - Airship/Location (14.2.0):
     - Airship/Core
-  - Airship/MessageCenter (14.1.3):
+  - Airship/MessageCenter (14.2.0):
     - Airship/Core
-  - AirshipExtensions/NotificationService (14.1.3)
+  - AirshipExtensions/NotificationService (14.2.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.63.4)
@@ -272,19 +272,19 @@ PODS:
     - React-Core
   - RNScreens (2.16.1):
     - React-Core
-  - urbanairship-accengage-react-native (9.0.1):
-    - Airship/Accengage (= 14.1.3)
+  - urbanairship-accengage-react-native (10.0.0):
+    - Airship/Accengage (= 14.2.0)
     - React-Core
-  - urbanairship-location-react-native (9.0.1):
-    - Airship/Location (= 14.1.3)
+  - urbanairship-location-react-native (10.0.0):
+    - Airship/Location (= 14.2.0)
     - React-Core
-  - urbanairship-react-native (9.0.1):
-    - Airship (= 14.1.3)
+  - urbanairship-react-native (10.0.0):
+    - Airship (= 14.2.0)
     - React-Core
   - Yoga (1.14.0)
 
 DEPENDENCIES:
-  - AirshipExtensions/NotificationService (~> 14.1.3)
+  - AirshipExtensions/NotificationService (~> 14.2.0)
   - DoubleConversion (from `../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../node_modules/react-native/Libraries/FBReactNativeSpec`)
@@ -399,8 +399,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: bb8fc010450ebb2c33314af9761bb79df4950dbc
-  AirshipExtensions: 709d5e7cffed738c487ae1fe0cca495ace6f7d74
+  Airship: 02ad73780f9eed21870e36b0aaab327acda6a102
+  AirshipExtensions: dae6544dc8c6977ccf03ea32dfb062cf0ed2b021
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
@@ -432,11 +432,11 @@ SPEC CHECKSUMS:
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
   RNScreens: 45c457af3d2ee9e08fc01e70da87e653d46b1198
-  urbanairship-accengage-react-native: 48d223a1251d567ea3f921fc8605aae81e1c39c6
-  urbanairship-location-react-native: 3e06f383751c32421c82adfc726a8edbef9a569c
-  urbanairship-react-native: 1a21e766162494ace776e8e35d231d63d074f616
+  urbanairship-accengage-react-native: d57723b2fe2045d4dd8cd5af19bdb4aa80b0f214
+  urbanairship-location-react-native: d7b289f1db1ebe14d240cfdc1c6d30de97793a4a
+  urbanairship-react-native: afab7684561909be2a6a2a52baa3435776d050de
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
-PODFILE CHECKSUM: 8d8b21ceb8d8d95f9f742a59ebc952ee55ea4563
+PODFILE CHECKSUM: 5820be3e3b56e627a80c61535fd3647306f748e8
 
 COCOAPODS: 1.10.0

--- a/urbanairship-accengage-react-native/android/build.gradle
+++ b/urbanairship-accengage-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.0.3"
+    airshipVersion = "14.1.0"
 }
 
 android {

--- a/urbanairship-accengage-react-native/package.json
+++ b/urbanairship-accengage-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-react-native",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Airship accengage module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
+++ b/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Accengage", "14.1.3"
+  s.dependency "Airship/Accengage", "14.2.0"
 
 end
 

--- a/urbanairship-hms-react-native/android/build.gradle
+++ b/urbanairship-hms-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.0.3"
+    airshipVersion = "14.1.0"
 }
 
 android {

--- a/urbanairship-hms-react-native/package.json
+++ b/urbanairship-hms-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-react-native",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Airship HMS module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/android/build.gradle
+++ b/urbanairship-location-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.0.3"
+    airshipVersion = "14.1.0"
 }
 
 android {

--- a/urbanairship-location-react-native/package.json
+++ b/urbanairship-location-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-location-react-native",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Airship location module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/urbanairship-location-react-native.podspec
+++ b/urbanairship-location-react-native/urbanairship-location-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Location", "14.1.3"
+  s.dependency "Airship/Location", "14.2.0"
 
 end
 

--- a/urbanairship-react-native/android/build.gradle
+++ b/urbanairship-react-native/android/build.gradle
@@ -41,5 +41,5 @@ dependencies {
     implementation "com.urbanairship.android:urbanairship-automation:$airshipVersion"
     implementation "com.urbanairship.android:urbanairship-location:$airshipVersion"
 
-    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '20.2.4')}"
+    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '21.0.0')}"
 }

--- a/urbanairship-react-native/android/build.gradle
+++ b/urbanairship-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.0.3"
+    airshipVersion = "14.1.0"
 }
 
 android {

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.java
@@ -39,6 +39,8 @@ public class ReactAutopilot extends Autopilot {
 
         PluginLogger.setLogLevel(airship.getAirshipConfigOptions().logLevel);
 
+        PluginLogger.debug("Airship React Native version: %s, SDK version: %s", BuildConfig.MODULE_VERSION, UAirship.getVersion());
+
         final Context context = UAirship.getApplicationContext();
 
         airship.setDeepLinkListener(new DeepLinkListener() {

--- a/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.m
@@ -7,7 +7,7 @@
 #import "UARCTModuleVersion.h"
 
 NSString *const UARCTPresentationOptionsStorageKey = @"com.urbanairship.presentation_options";
-NSString *const UARCTAirshipRecommendedVersion = @"13.5.4";
+NSString *const UARCTAirshipRecommendedVersion = @"14.2.0";
 
 @implementation UARCTAutopilot
 
@@ -29,6 +29,7 @@ static BOOL disabled = NO;
 
     [UAirship takeOff];
 
+    UA_LINFO(@"Airship ReactNative version: %@, SDK version: %@", [UARCTModuleVersion get], [UAirshipVersion get]);
     [[UAirship analytics] registerSDKExtension:UASDKExtensionReactNative version:[UARCTModuleVersion get]];
 
     [UAirship push].pushNotificationDelegate = [UARCTEventEmitter shared];
@@ -48,6 +49,7 @@ static BOOL disabled = NO;
 
     if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTPresentationOptionsStorageKey]) {
         UNNotificationPresentationOptions presentationOptions = [[NSUserDefaults standardUserDefaults] integerForKey:UARCTPresentationOptionsStorageKey];
+        UA_LDEBUG(@"Foreground presentation options set: %lu", (unsigned long)presentationOptions);
         [[UAirship push] setDefaultPresentationOptions:presentationOptions];
     }
 

--- a/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const airshipModuleVersionString = @"9.0.1";
+NSString *const airshipModuleVersionString = @"10.0.0";
 
 + (nonnull NSString *)get {
     return airshipModuleVersionString;

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -298,7 +298,7 @@ RCT_EXPORT_METHOD(setForegroundPresentationOptions:(NSDictionary *)options) {
         }
     }
 
-    UA_LDEBUG(@"Foreground presentation options set: %lu", (unsigned long)options);
+    UA_LDEBUG(@"Foreground presentation options set: %lu from dictionary: %@", (unsigned long)presentationOptions, options);
 
     [UAirship push].defaultPresentationOptions = presentationOptions;
     [[NSUserDefaults standardUserDefaults] setInteger:presentationOptions

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -103,7 +103,7 @@ export interface InboxMessage {
   /**
    * String to String map of any message extras.
    */
-  extras: Map<string, string>;
+  extras: Record<string, string>;
 }
 
 /**

--- a/urbanairship-react-native/package.json
+++ b/urbanairship-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Airship plugin for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-react-native/urbanairship-react-native.podspec
+++ b/urbanairship-react-native/urbanairship-react-native.podspec
@@ -14,6 +14,6 @@ require "json"
   s.source       = { :git => "https://github.com/urbanairship/react-native-module.git", :tag => "{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
   s.dependency "React-Core"
-  s.dependency "Airship", "14.1.3"
+  s.dependency "Airship", "14.2.0"
 
 end


### PR DESCRIPTION
Release 10.0.0. I did a major release since we changed the type for InboxMessage extras as well as requiring Xcode 12.

I added some logging for SDK and module version, and fixed the logging for foreground presentation options to hopefully help debug https://github.com/urbanairship/react-native-module/issues/298