### PR TITLE
[MOBILE-2044] Ensure takeOff is called before accessing the module

### DIFF
--- a/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.h
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.h
@@ -22,4 +22,9 @@ extern NSString *const UARCTAirshipRecommendedVersion;
  */
 + (void)disable;
 
+/**
+ * Performs takeOff.
+ */
++ (void)takeOff;
+
 @end

--- a/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTAutopilot.m
@@ -19,49 +19,52 @@ static BOOL disabled = NO;
 
 + (void)load {
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center addObserver:[UARCTAutopilot class] selector:@selector(performTakeOff:) name:UIApplicationDidFinishLaunchingNotification object:nil];
+    [center addObserver:[UARCTAutopilot class] selector:@selector(takeOff) name:UIApplicationDidFinishLaunchingNotification object:nil];
 }
 
-+ (void)performTakeOff:(NSNotification *)notification {
++ (void)takeOff {
     if (disabled) {
         return;
     }
 
-    [UAirship takeOff];
+    static dispatch_once_t takeOffdispatchOnce_;
+    dispatch_once(&takeOffdispatchOnce_, ^{
+        [UAirship takeOff];
 
-    UA_LINFO(@"Airship ReactNative version: %@, SDK version: %@", [UARCTModuleVersion get], [UAirshipVersion get]);
-    [[UAirship analytics] registerSDKExtension:UASDKExtensionReactNative version:[UARCTModuleVersion get]];
+        UA_LINFO(@"Airship ReactNative version: %@, SDK version: %@", [UARCTModuleVersion get], [UAirshipVersion get]);
+        [[UAirship analytics] registerSDKExtension:UASDKExtensionReactNative version:[UARCTModuleVersion get]];
 
-    [UAirship push].pushNotificationDelegate = [UARCTEventEmitter shared];
-    [UAirship push].registrationDelegate = [UARCTEventEmitter shared];
-    [UAMessageCenter shared].displayDelegate  = [UARCTMessageCenter shared];
+        [UAirship push].pushNotificationDelegate = [UARCTEventEmitter shared];
+        [UAirship push].registrationDelegate = [UARCTEventEmitter shared];
+        [UAMessageCenter shared].displayDelegate  = [UARCTMessageCenter shared];
 
-    // Register custom deep link action
-    UARCTDeepLinkAction *dle = [[UARCTDeepLinkAction alloc] init];
-    [[UAirship shared].actionRegistry updateAction:dle forEntryWithName:UADeepLinkActionDefaultRegistryName];
-    dle.deepLinkDelegate = [UARCTEventEmitter shared];
+        // Register custom deep link action
+        UARCTDeepLinkAction *dle = [[UARCTDeepLinkAction alloc] init];
+        [[UAirship shared].actionRegistry updateAction:dle forEntryWithName:UADeepLinkActionDefaultRegistryName];
+        dle.deepLinkDelegate = [UARCTEventEmitter shared];
 
-    // Add observer for inbox updated event
-    [[NSNotificationCenter defaultCenter] addObserver:[UARCTEventEmitter shared]
-                                         selector:@selector(inboxUpdated)
-                                             name:UAInboxMessageListUpdatedNotification
-                                           object:nil];
+        // Add observer for inbox updated event
+        [[NSNotificationCenter defaultCenter] addObserver:[UARCTEventEmitter shared]
+                                            selector:@selector(inboxUpdated)
+                                                name:UAInboxMessageListUpdatedNotification
+                                            object:nil];
 
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTPresentationOptionsStorageKey]) {
-        UNNotificationPresentationOptions presentationOptions = [[NSUserDefaults standardUserDefaults] integerForKey:UARCTPresentationOptionsStorageKey];
-        UA_LDEBUG(@"Foreground presentation options set: %lu", (unsigned long)presentationOptions);
-        [[UAirship push] setDefaultPresentationOptions:presentationOptions];
-    }
+        if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTPresentationOptionsStorageKey]) {
+            UNNotificationPresentationOptions presentationOptions = [[NSUserDefaults standardUserDefaults] integerForKey:UARCTPresentationOptionsStorageKey];
+            UA_LDEBUG(@"Foreground presentation options set: %lu", (unsigned long)presentationOptions);
+            [[UAirship push] setDefaultPresentationOptions:presentationOptions];
+        }
 
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTAutoLaunchMessageCenterKey] == nil) {
-        [[NSUserDefaults standardUserDefaults] setBool:true forKey:UARCTAutoLaunchMessageCenterKey];
-    }
+        if ([[NSUserDefaults standardUserDefaults] objectForKey:UARCTAutoLaunchMessageCenterKey] == nil) {
+            [[NSUserDefaults standardUserDefaults] setBool:true forKey:UARCTAutoLaunchMessageCenterKey];
+        }
 
-    if (([UARCTAirshipRecommendedVersion compare:[UAirshipVersion get] options:NSNumericSearch] == NSOrderedDescending)) {
-         UA_LIMPERR(@"Current version of Airship is below the recommended version. Current version: %@ Recommended version: %@", [UAirshipVersion get], UARCTAirshipRecommendedVersion);
-    }
+        if (([UARCTAirshipRecommendedVersion compare:[UAirshipVersion get] options:NSNumericSearch] == NSOrderedDescending)) {
+            UA_LIMPERR(@"Current version of Airship is below the recommended version. Current version: %@ Recommended version: %@", [UAirshipVersion get], UARCTAirshipRecommendedVersion);
+        }
 
-    [self loadCustomNotificationCategories];
+        [self loadCustomNotificationCategories];
+    });
 }
 
 + (void)loadCustomNotificationCategories {

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -45,6 +45,18 @@ RCT_EXPORT_MODULE();
     return [UARCTEventEmitter shared].bridge;
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
+- (instancetype)init{
+    self = [super init];
+    if (self) {
+        [UARCTAutopilot takeOff];
+    }
+    return self;
+}
+
 #pragma mark -
 #pragma mark Module methods
 


### PR DESCRIPTION
Calls takeOff when the module is created. Left the NSNotificationCenter method in place in case the module is loaded at a later time after application:didFinishLaunching: