### PR TITLE
[MOBILE-2159] Make it possible to extend airship during takeoff

### DIFF
--- a/urbanairship-react-native/android/build.gradle
+++ b/urbanairship-react-native/android/build.gradle
@@ -16,6 +16,7 @@ android {
         minSdkVersion 16
 
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
+        consumerProguardFiles 'proguard-rules.pro'
     }
 }
 
@@ -33,13 +34,13 @@ def safeExtGet (prop, fallback) {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 
-    implementation("com.urbanairship.android:urbanairship-fcm:$airshipVersion") {
+    api ("com.urbanairship.android:urbanairship-fcm:$airshipVersion") {
       exclude group: 'com.google.firebase', module: 'firebase-messaging'
     }
 
-    implementation "com.urbanairship.android:urbanairship-message-center:$airshipVersion"
-    implementation "com.urbanairship.android:urbanairship-automation:$airshipVersion"
-    implementation "com.urbanairship.android:urbanairship-location:$airshipVersion"
+    api "com.urbanairship.android:urbanairship-message-center:$airshipVersion"
+    api "com.urbanairship.android:urbanairship-automation:$airshipVersion"
+    api "com.urbanairship.android:urbanairship-location:$airshipVersion"
 
     implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '21.0.0')}"
 }

--- a/urbanairship-react-native/android/proguard-rules.pro
+++ b/urbanairship-react-native/android/proguard-rules.pro
@@ -1,0 +1,4 @@
+
+## Airship extender
+-keep public class com.urbanairship.reactnative.AirshipExtender
+-keep public class * extends com.urbanairship.reactnative.AirshipExtender

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/AirshipExtender.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/AirshipExtender.java
@@ -1,0 +1,16 @@
+package com.urbanairship.reactnative;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.urbanairship.UAirship;
+
+/**
+ * Extender that will be called during takeOff to customize the airship instance.
+ * Register the extender fully qualified class name in the manifest under the key
+ * `com.urbanairship.reactnative.AIRSHIP_EXTENDER`.
+ */
+public interface AirshipExtender {
+    void onAirshipReady(@NonNull Context context, @NonNull UAirship airship);
+}

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactNotificationProvider.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactNotificationProvider.java
@@ -13,9 +13,9 @@ import com.urbanairship.push.notifications.AirshipNotificationProvider;
 
 public class ReactNotificationProvider extends AirshipNotificationProvider {
 
-    private Context context;
+    protected final Context context;
 
-    ReactNotificationProvider(@NonNull Context context, @NonNull AirshipConfigOptions configOptions) {
+    public ReactNotificationProvider(@NonNull Context context, @NonNull AirshipConfigOptions configOptions) {
         super(context, configOptions);
         this.context = context;
     }


### PR DESCRIPTION
Adds a hook to customize airship before takeOff finishes so apps can set things like custom notification providers.

I tested this in the sample app with https://gist.github.com/rlepinski/d82229595538d897acc35fa294f35e3f