### PR TITLE
[MOBILE-2136] release 11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # React Native Module Changelog
 
+## Version 11.0.0 - March 25, 2021
+Major release updating the iOS and Android SDKs to 14.3.0. This release contains small breaking changes to the event handling API, and also adds an extender to Android making it easier to modify the Airship instance during takeOff.
+
+- Updated iOS SDK to 14.3.0
+- Updated Android SDK to 14.3.0
+- PushReceived and background NotificationResponse events are now triggered in the background on Android. To maintain UI thread safety, apps should now clean up any listeners that might modify the UI during `componentWillUnmount`.
+- UrbanAirship.addListener now returns `Subscription` instead of `EmitterSubscription`
+- Added AirshipExtender to Android to make it easier to modify the Airship instance during takeOff
+
 ## Version 10.0.2 - February 02, 2021
 Patch release to fix some issues with setting attributes on a named user if the named user ID contains invalid URL characters. Applications using attributes with named users that possibly contain invalid URL characters should update.
 

--- a/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
+++ b/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipAccengageReactModuleVersion.h"
 
-NSString *const moduleVersionString = @"10.0.2";
+NSString *const moduleVersionString = @"11.0.0";
 
 @implementation AirshipAccengageReactModuleVersion
 

--- a/urbanairship-accengage-react-native/package.json
+++ b/urbanairship-accengage-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-react-native",
-  "version": "10.0.2",
+  "version": "11.0.0",
   "description": "Airship accengage module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-hms-react-native/package.json
+++ b/urbanairship-hms-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-react-native",
-  "version": "10.0.2",
+  "version": "11.0.0",
   "description": "Airship HMS module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
+++ b/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipLocationReactModuleVersion.h"
 
-NSString *const airshipLocationModuleVersionString = @"10.0.2";
+NSString *const airshipLocationModuleVersionString = @"11.0.0";
 
 @implementation AirshipLocationReactModuleVersion
 

--- a/urbanairship-location-react-native/package.json
+++ b/urbanairship-location-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-location-react-native",
-  "version": "10.0.2",
+  "version": "11.0.0",
   "description": "Airship location module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const airshipModuleVersionString = @"10.0.2";
+NSString *const airshipModuleVersionString = @"11.0.0";
 
 + (nonnull NSString *)get {
     return airshipModuleVersionString;

--- a/urbanairship-react-native/package.json
+++ b/urbanairship-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "10.0.2",
+  "version": "11.0.0",
   "description": "Airship plugin for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",


### PR DESCRIPTION
This release technically also supports React Native 0.6.4/React 17 but we don't need to call that out. Minimum requirements remain the same.