### PR TITLE
Release 11.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # React Native Module Changelog
 
+## Version 11.0.1 - May 3, 2021
+Patch release to fix NPE on Android when opening notifications. Any app using 11.0.0 should update.
+
+- Fixed NPE on Android.
+
 ## Version 11.0.0 - March 25, 2021
 Major release updating the iOS and Android SDKs to 14.3.0. This release contains small breaking changes to the event handling API, and also adds an extender to Android making it easier to modify the Airship instance during takeOff.
 

--- a/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
+++ b/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipAccengageReactModuleVersion.h"
 
-NSString *const moduleVersionString = @"11.0.0";
+NSString *const moduleVersionString = @"11.0.1";
 
 @implementation AirshipAccengageReactModuleVersion
 

--- a/urbanairship-accengage-react-native/package.json
+++ b/urbanairship-accengage-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-react-native",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Airship accengage module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-hms-react-native/package.json
+++ b/urbanairship-hms-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-react-native",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Airship HMS module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
+++ b/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipLocationReactModuleVersion.h"
 
-NSString *const airshipLocationModuleVersionString = @"11.0.0";
+NSString *const airshipLocationModuleVersionString = @"11.0.1";
 
 @implementation AirshipLocationReactModuleVersion
 

--- a/urbanairship-location-react-native/package.json
+++ b/urbanairship-location-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-location-react-native",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Airship location module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/events/NotificationResponseEvent.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/events/NotificationResponseEvent.java
@@ -67,9 +67,8 @@ public class NotificationResponseEvent implements Event {
         return map;
     }
 
-
     @Override
     public boolean isForeground() {
-        return actionButtonInfo.isForeground();
+        return actionButtonInfo != null ? actionButtonInfo.isForeground() : true;
     }
 }

--- a/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const airshipModuleVersionString = @"11.0.0";
+NSString *const airshipModuleVersionString = @"11.0.1";
 
 + (nonnull NSString *)get {
     return airshipModuleVersionString;

--- a/urbanairship-react-native/package.json
+++ b/urbanairship-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Airship plugin for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",


### PR DESCRIPTION
Fixes NPE regression introduced in 11.0.0. Reported here - https://github.com/urbanairship/react-native-module/issues/319

I verified the fix by opening a push on Android. 