### PR TITLE
[MOBILE-2357] Update React Module to SDKs 14.4.x

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -13,7 +13,7 @@ end
 target 'ServiceExtension' do
   platform :ios, '11.0'
   # Pods for Service Extension
-  pod 'AirshipExtensions/NotificationService', '~> 14.3.0'
+  pod 'AirshipExtensions/NotificationService', '~> 14.4.2'
 end
 
 # https://github.com/software-mansion/react-native-screens/issues/842

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Airship (14.3.0):
-    - Airship/Automation (= 14.3.0)
-    - Airship/Core (= 14.3.0)
-    - Airship/ExtendedActions (= 14.3.0)
-    - Airship/MessageCenter (= 14.3.0)
-  - Airship/Accengage (14.3.0):
+  - Airship (14.4.2):
+    - Airship/Automation (= 14.4.2)
+    - Airship/Core (= 14.4.2)
+    - Airship/ExtendedActions (= 14.4.2)
+    - Airship/MessageCenter (= 14.4.2)
+  - Airship/Accengage (14.4.2):
     - Airship/Core
-  - Airship/Automation (14.3.0):
+  - Airship/Automation (14.4.2):
     - Airship/Core
-  - Airship/Core (14.3.0)
-  - Airship/ExtendedActions (14.3.0):
+  - Airship/Core (14.4.2)
+  - Airship/ExtendedActions (14.4.2):
     - Airship/Core
-  - Airship/Location (14.3.0):
+  - Airship/Location (14.4.2):
     - Airship/Core
-  - Airship/MessageCenter (14.3.0):
+  - Airship/MessageCenter (14.4.2):
     - Airship/Core
-  - AirshipExtensions/NotificationService (14.2.3)
+  - AirshipExtensions/NotificationService (14.4.2)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.64.0)
@@ -294,19 +294,19 @@ PODS:
     - React-Core
   - RNScreens (2.18.1):
     - React-Core
-  - urbanairship-accengage-react-native (10.0.2):
-    - Airship/Accengage (= 14.3.0)
+  - urbanairship-accengage-react-native (11.0.2):
+    - Airship/Accengage (= 14.4.2)
     - React-Core
-  - urbanairship-location-react-native (10.0.2):
-    - Airship/Location (= 14.3.0)
+  - urbanairship-location-react-native (11.0.2):
+    - Airship/Location (= 14.4.2)
     - React-Core
-  - urbanairship-react-native (10.0.2):
-    - Airship (= 14.3.0)
+  - urbanairship-react-native (11.0.2):
+    - Airship (= 14.4.2)
     - React-Core
   - Yoga (1.14.0)
 
 DEPENDENCIES:
-  - AirshipExtensions/NotificationService (~> 14.2.0)
+  - AirshipExtensions/NotificationService (~> 14.4.2)
   - DoubleConversion (from `../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../node_modules/react-native/React/FBReactNativeSpec`)
@@ -427,12 +427,12 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: 7609d263d3a207f112d6db066af5852b80af6819
-  AirshipExtensions: 0b719f53da680f40af3e7df8ccf04f9b2ae31d59
+  Airship: 29d674abeac754f783fc46c7d383d6f046687341
+  AirshipExtensions: 97f69284615efa0a3b2171c4446dcdc07cd5ec6b
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: a53892a1779149911a1c3afb6ca449f919aa7f75
+  FBReactNativeSpec: 7c6d712cdaaf4e87575f8c2700d676f0bcbda9bc
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
@@ -462,11 +462,11 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 514a11da3a2bcc6c3dfd9de32b38e2b9bf101926
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
-  urbanairship-accengage-react-native: 5f96e9e8ffdbc189bada73c9aa51677a50d91031
-  urbanairship-location-react-native: 91322090f3e0c632337bcaefb9c849f9af7640f1
-  urbanairship-react-native: 5de3616d043e3062b3ed418641152369e951a7c0
+  urbanairship-accengage-react-native: ae2fcc955f135952f0304add6eb272522d4ae6aa
+  urbanairship-location-react-native: a74df56807186e0f638acf31fdc65b6abdb70acf
+  urbanairship-react-native: ee53526e1f81c5170863dd3e039df7f98730ef53
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: 6cf0ae86fd1504ef483e70f51a6a27db2e380c37
+PODFILE CHECKSUM: c85a34525a10917ea53296c15827351b110d4fc0
 
 COCOAPODS: 1.10.1

--- a/urbanairship-accengage-react-native/android/build.gradle
+++ b/urbanairship-accengage-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.1.1"
+    airshipVersion = "14.4.4"
 }
 
 android {

--- a/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
+++ b/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipAccengageReactModuleVersion.h"
 
-NSString *const moduleVersionString = @"11.0.1";
+NSString *const moduleVersionString = @"11.0.2";
 
 @implementation AirshipAccengageReactModuleVersion
 

--- a/urbanairship-accengage-react-native/package.json
+++ b/urbanairship-accengage-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-react-native",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Airship accengage module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
+++ b/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Accengage", "14.3.0"
+  s.dependency "Airship/Accengage", "14.4.2"
 
 end
 

--- a/urbanairship-hms-react-native/android/build.gradle
+++ b/urbanairship-hms-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.3.0"
+    airshipVersion = "14.4.4"
 }
 
 android {

--- a/urbanairship-hms-react-native/package.json
+++ b/urbanairship-hms-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-react-native",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Airship HMS module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/android/build.gradle
+++ b/urbanairship-location-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.1.1"
+    airshipVersion = "14.4.4"
 }
 
 android {

--- a/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
+++ b/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipLocationReactModuleVersion.h"
 
-NSString *const airshipLocationModuleVersionString = @"11.0.1";
+NSString *const airshipLocationModuleVersionString = @"11.0.2";
 
 @implementation AirshipLocationReactModuleVersion
 

--- a/urbanairship-location-react-native/package.json
+++ b/urbanairship-location-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-location-react-native",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Airship location module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/urbanairship-location-react-native.podspec
+++ b/urbanairship-location-react-native/urbanairship-location-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Location", "14.3.0"
+  s.dependency "Airship/Location", "14.4.2"
 
 end
 

--- a/urbanairship-react-native/android/build.gradle
+++ b/urbanairship-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.3.0"
+    airshipVersion = "14.4.4"
 }
 
 android {

--- a/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const airshipModuleVersionString = @"11.0.1";
+NSString *const airshipModuleVersionString = @"11.0.2";
 
 + (nonnull NSString *)get {
     return airshipModuleVersionString;

--- a/urbanairship-react-native/package.json
+++ b/urbanairship-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Airship plugin for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-react-native/urbanairship-react-native.podspec
+++ b/urbanairship-react-native/urbanairship-react-native.podspec
@@ -13,6 +13,6 @@ require "json"
   s.source       = { :git => "https://github.com/urbanairship/react-native-module.git", :tag => "{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
   s.dependency "React-Core"
-  s.dependency "Airship", "14.3.0"
+  s.dependency "Airship", "14.4.2"
 
 end


### PR DESCRIPTION
### What do these changes do?
Update the React Native plugin to 11.0.2, and the native SDKs version to 14.4.4 for Android, and 14.4.2 for iOS

### Why are these changes necessary?
To keep the SDKs up to date

### How did you verify these changes?
By running the sample apps 
