### PR TITLE
[MOBILE-2359] Expose new privacy manager flags

### DIFF
--- a/example/ios/AirshipSample.xcodeproj/project.pbxproj
+++ b/example/ios/AirshipSample.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
@@ -290,139 +290,20 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AirshipSample/Pods-AirshipSample-resources.sh",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/de.lproj/AirshipAccengage.strings",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/en.lproj/AirshipAccengage.strings",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/es.lproj/AirshipAccengage.strings",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/fr.lproj/AirshipAccengage.strings",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/it.lproj/AirshipAccengage.strings",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/ru.lproj/AirshipAccengage.strings",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/ios/UAAccengageNotificationCategories.plist",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/de.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/en.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/es.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/fr.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/it.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/common/ru.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipAccengage/Resources/ios",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAAutomationActions.plist",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAInAppMessageBannerContentView.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAInAppMessageBannerView.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAInAppMessageButtonView.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAInAppMessageFullScreenViewController.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAInAppMessageHTMLViewController.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAInAppMessageModalViewController.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAInAppMessageResizableViewController.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAAutomation.xcdatamodeld",
-				"${PODS_ROOT}/Airship/Airship/AirshipAutomation/Resources/UAFrequencyLimits.xcdatamodeld",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/UADefaultActions.plist",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/UADefaultActionsTvOS.plist",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/UANativeBridge",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/UANotificationCategories.plist",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/ar.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/cs.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/da.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/de.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/en.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/es-419.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/es.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/fi.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/fr.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/hi.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/hu.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/id.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/it.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/iw.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/ja.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/ko.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/ms.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/nl.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/no.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/pl.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/pt-PT.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/pt.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/ro.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/ru.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/sk.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/sv.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/th.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/tr.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/UAEvents.xcdatamodeld",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/UARemoteData.xcdatamodeld",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/vi.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/zh-Hans.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipCore/Resources/zh-Hant.lproj",
-				"${PODS_ROOT}/Airship/Airship/AirshipExtendedActions/Resources/UAExtendedActions.plist",
-				"${PODS_ROOT}/Airship/Airship/AirshipExtendedActions/Resources/UARateAppPromptView.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipMessageCenter/Resources/UADefaultMessageCenterListViewController.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipMessageCenter/Resources/UADefaultMessageCenterMessageViewController.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipMessageCenter/Resources/UAMessageCenterActions.plist",
-				"${PODS_ROOT}/Airship/Airship/AirshipMessageCenter/Resources/UAMessageCenterListCell.xib",
-				"${PODS_ROOT}/Airship/Airship/AirshipMessageCenter/Resources/UAMessageCenterPlaceholderIcon.png",
-				"${PODS_ROOT}/Airship/Airship/AirshipMessageCenter/Resources/UAInbox.xcdatamodeld",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Airship/AirshipAccengageResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Airship/AirshipAutomationResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Airship/AirshipCoreResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Airship/AirshipExtendedActionsResources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Airship/AirshipMessageCenterResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AirshipAccengage.strings",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAAccengageNotificationCategories.plist",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/common",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/de.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/en.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/es.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/fr.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/it.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ru.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ios",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAAutomationActions.plist",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInAppMessageBannerContentView.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInAppMessageBannerView.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInAppMessageButtonView.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInAppMessageFullScreenViewController.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInAppMessageHTMLViewController.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInAppMessageModalViewController.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInAppMessageResizableViewController.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAAutomation.momd",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAFrequencyLimits.momd",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UADefaultActions.plist",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UADefaultActionsTvOS.plist",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UANativeBridge",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UANotificationCategories.plist",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ar.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cs.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/da.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/es-419.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/fi.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/hi.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/hu.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/id.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/iw.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ja.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ko.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ms.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/nl.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/no.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/pl.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/pt-PT.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/pt.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ro.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/sk.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/sv.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/th.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/tr.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAEvents.momd",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UARemoteData.momd",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/vi.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/zh-Hans.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/zh-Hant.lproj",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAExtendedActions.plist",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UARateAppPromptView.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UADefaultMessageCenterListViewController.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UADefaultMessageCenterMessageViewController.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAMessageCenterActions.plist",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAMessageCenterListCell.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAMessageCenterPlaceholderIcon.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/UAInbox.momd",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AirshipAccengageResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AirshipAutomationResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AirshipCoreResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AirshipExtendedActionsResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AirshipMessageCenterResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -546,7 +427,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = PGJV57GD94;
 				INFOPLIST_FILE = AirshipSample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -568,7 +449,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = PGJV57GD94;
 				INFOPLIST_FILE = AirshipSample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -603,6 +484,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -627,7 +509,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -657,6 +539,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -674,7 +557,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
@@ -698,7 +581,7 @@
 				DEVELOPMENT_TEAM = PGJV57GD94;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = ServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -726,7 +609,7 @@
 				DEVELOPMENT_TEAM = PGJV57GD94;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = ServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.urbanairship.richpush.ServiceExtension;

--- a/example/ios/AirshipSample.xcodeproj/xcshareddata/xcschemes/AirshipSample.xcscheme
+++ b/example/ios/AirshipSample.xcodeproj/xcshareddata/xcschemes/AirshipSample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -13,7 +13,7 @@ end
 target 'ServiceExtension' do
   platform :ios, '11.0'
   # Pods for Service Extension
-  pod 'AirshipExtensions/NotificationService', '~> 14.4.2'
+  pod 'AirshipExtensions/NotificationService', '~> 14.5.1'
 end
 
 # https://github.com/software-mansion/react-native-screens/issues/842

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Airship (14.4.2):
-    - Airship/Automation (= 14.4.2)
-    - Airship/Core (= 14.4.2)
-    - Airship/ExtendedActions (= 14.4.2)
-    - Airship/MessageCenter (= 14.4.2)
-  - Airship/Accengage (14.4.2):
+  - Airship (14.5.1):
+    - Airship/Automation (= 14.5.1)
+    - Airship/Core (= 14.5.1)
+    - Airship/ExtendedActions (= 14.5.1)
+    - Airship/MessageCenter (= 14.5.1)
+  - Airship/Accengage (14.5.1):
     - Airship/Core
-  - Airship/Automation (14.4.2):
+  - Airship/Automation (14.5.1):
     - Airship/Core
-  - Airship/Core (14.4.2)
-  - Airship/ExtendedActions (14.4.2):
+  - Airship/Core (14.5.1)
+  - Airship/ExtendedActions (14.5.1):
     - Airship/Core
-  - Airship/Location (14.4.2):
+  - Airship/Location (14.5.1):
     - Airship/Core
-  - Airship/MessageCenter (14.4.2):
+  - Airship/MessageCenter (14.5.1):
     - Airship/Core
-  - AirshipExtensions/NotificationService (14.4.2)
+  - AirshipExtensions/NotificationService (14.5.1)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.64.0)
@@ -294,19 +294,19 @@ PODS:
     - React-Core
   - RNScreens (2.18.1):
     - React-Core
-  - urbanairship-accengage-react-native (11.0.2):
-    - Airship/Accengage (= 14.4.2)
+  - urbanairship-accengage-react-native (12.0.0):
+    - Airship/Accengage (= 14.5.1)
     - React-Core
-  - urbanairship-location-react-native (11.0.2):
-    - Airship/Location (= 14.4.2)
+  - urbanairship-location-react-native (12.0.0):
+    - Airship/Location (= 14.5.1)
     - React-Core
-  - urbanairship-react-native (11.0.2):
-    - Airship (= 14.4.2)
+  - urbanairship-react-native (12.0.0):
+    - Airship (= 14.5.1)
     - React-Core
   - Yoga (1.14.0)
 
 DEPENDENCIES:
-  - AirshipExtensions/NotificationService (~> 14.4.2)
+  - AirshipExtensions/NotificationService (~> 14.5.1)
   - DoubleConversion (from `../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../node_modules/react-native/React/FBReactNativeSpec`)
@@ -427,12 +427,12 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: 29d674abeac754f783fc46c7d383d6f046687341
-  AirshipExtensions: 97f69284615efa0a3b2171c4446dcdc07cd5ec6b
+  Airship: 8aafab3ca796aca500ec3199e7afb0d721da5231
+  AirshipExtensions: 3dbf2aeb9e3d36245e68321058b8097d2a0551a0
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 7c6d712cdaaf4e87575f8c2700d676f0bcbda9bc
+  FBReactNativeSpec: e14effdeddf56213637f24d33948c06c86980186
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
@@ -462,11 +462,11 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 514a11da3a2bcc6c3dfd9de32b38e2b9bf101926
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
-  urbanairship-accengage-react-native: ae2fcc955f135952f0304add6eb272522d4ae6aa
-  urbanairship-location-react-native: a74df56807186e0f638acf31fdc65b6abdb70acf
-  urbanairship-react-native: ee53526e1f81c5170863dd3e039df7f98730ef53
+  urbanairship-accengage-react-native: e22a70e812ab211d7460d94e1050b87c8d7aa4b1
+  urbanairship-location-react-native: 36bd01ada0f5e9dca1ce70006f6938703c61bdcd
+  urbanairship-react-native: 670ce67ca1463a7233ac3b75a47943575bd071b4
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: c85a34525a10917ea53296c15827351b110d4fc0
+PODFILE CHECKSUM: 42d6853d5b3b5d38353be9eb4519a6359f0c0ad6
 
 COCOAPODS: 1.10.1

--- a/urbanairship-accengage-react-native/android/build.gradle
+++ b/urbanairship-accengage-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.4.4"
+    airshipVersion = "14.5.1"
 }
 
 android {

--- a/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
+++ b/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipAccengageReactModuleVersion.h"
 
-NSString *const moduleVersionString = @"11.0.2";
+NSString *const moduleVersionString = @"12.0.0";
 
 @implementation AirshipAccengageReactModuleVersion
 

--- a/urbanairship-accengage-react-native/package.json
+++ b/urbanairship-accengage-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-react-native",
-  "version": "11.0.2",
+  "version": "12.0.0",
   "description": "Airship accengage module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
+++ b/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Accengage", "14.4.2"
+  s.dependency "Airship/Accengage", "14.5.1"
 
 end
 

--- a/urbanairship-hms-react-native/android/build.gradle
+++ b/urbanairship-hms-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.4.4"
+    airshipVersion = "14.5.1"
 }
 
 android {

--- a/urbanairship-hms-react-native/package.json
+++ b/urbanairship-hms-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-react-native",
-  "version": "11.0.2",
+  "version": "12.0.0",
   "description": "Airship HMS module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/android/build.gradle
+++ b/urbanairship-location-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.4.4"
+    airshipVersion = "14.5.1"
 }
 
 android {

--- a/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
+++ b/urbanairship-location-react-native/ios/AirshipLocationReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipLocationReactModuleVersion.h"
 
-NSString *const airshipLocationModuleVersionString = @"11.0.2";
+NSString *const airshipLocationModuleVersionString = @"12.0.0";
 
 @implementation AirshipLocationReactModuleVersion
 

--- a/urbanairship-location-react-native/package.json
+++ b/urbanairship-location-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-location-react-native",
-  "version": "11.0.2",
+  "version": "12.0.0",
   "description": "Airship location module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-location-react-native/urbanairship-location-react-native.podspec
+++ b/urbanairship-location-react-native/urbanairship-location-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Location", "14.4.2"
+  s.dependency "Airship/Location", "14.5.1"
 
 end
 

--- a/urbanairship-react-native/android/build.gradle
+++ b/urbanairship-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "14.4.4"
+    airshipVersion = "14.5.1"
 }
 
 android {
@@ -42,5 +42,5 @@ dependencies {
     api "com.urbanairship.android:urbanairship-automation:$airshipVersion"
     api "com.urbanairship.android:urbanairship-location:$airshipVersion"
 
-    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '21.0.0')}"
+    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '22.0.0')}"
 }

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -27,6 +27,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.urbanairship.PrivacyManager;
 import com.urbanairship.UAirship;
 import com.urbanairship.actions.ActionArguments;
 import com.urbanairship.actions.ActionCompletionCallback;
@@ -187,43 +188,68 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Enables/disables data collection.
+     * Sets the current enabled features.
      *
-     * @param enabled {@code true} to allow data collection., {@code false} to disallow.
+     * @param features The features to set as enabled.
      */
     @ReactMethod
-    public void setDataCollectionEnabled(boolean enabled) {
-        UAirship.shared().setDataCollectionEnabled(enabled);
+    public void setEnabledFeatures(ReadableArray features) {
+        UAirship.shared().getPrivacyManager().setEnabledFeatures(parseStringFeatures(features));
     }
 
     /**
-     * Checks if data collection is enabled.
+     * Gets the current enabled features.
      *
-     * @param promise The JS promise.
+     * @param promise  The promise.
+     * @return The enabled features.
      */
     @ReactMethod
-    public void isDataCollectionEnabled(Promise promise) {
-        promise.resolve(UAirship.shared().isDataCollectionEnabled());
+    public void getEnabledFeatures(Promise promise) {
+        promise.resolve(UAirship.shared().getPrivacyManager().getEnabledFeatures());
     }
 
     /**
-     * Enables/disables push token registration.
+     * Enables features.
      *
-     * @param enabled {@code true} to allow push token registration., {@code false} to disallow.
+     * @param features The features to enable.
      */
     @ReactMethod
-    public void setPushTokenRegistrationEnabled(boolean enabled) {
-        UAirship.shared().getPushManager().setPushTokenRegistrationEnabled(enabled);
+    public void enableFeature(ReadableArray features) {
+        UAirship.shared().getPrivacyManager().enable(parseStringFeatures(features));
     }
 
     /**
-     * Checks if push token registration is enabled.
+     * Disables features.
      *
-     * @param promise The JS promise.
+     * @param features The features to disable.
      */
     @ReactMethod
-    public void isPushTokenRegistrationEnabled(Promise promise) {
-        promise.resolve(UAirship.shared().getPushManager().isPushTokenRegistrationEnabled());
+    public void disableFeature(ReadableArray features) {
+        UAirship.shared().getPrivacyManager().disable(parseStringFeatures(features));
+    }
+
+    /**
+     * Checks if a given feature is enabled.
+     *
+     * @param features The features to check.
+     * @param promise  The promise.
+     * @return {@code true} if the provided features are enabled, otherwise {@code false}.
+     */
+    @ReactMethod
+    public void isFeatureEnabled(ReadableArray features, Promise promise) {
+        promise.resolve(UAirship.shared().getPrivacyManager().isEnabled(parseStringFeatures(features)));
+    }
+
+    /**
+     * Checks if any of the given features is enabled.
+     *
+     * @param features The features to check.
+     * @param promise  The promise.
+     * @return {@code true} if any of the provided features is enabled, otherwise {@code false}.
+     */
+    @ReactMethod
+    public void isFeatureAnyEnabled(ReadableArray features, Promise promise) {
+        promise.resolve(UAirship.shared().getPrivacyManager().isAnyEnabled(parseStringFeatures(features)));
     }
 
     /**
@@ -834,6 +860,53 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
             Event optInEvent = new NotificationOptInEvent(optIn);
             EventEmitter.shared().sendEvent(optInEvent);
         }
+    }
+
+    /**
+     * Helper method to parse a String array into {@link PrivacyManager.Feature} array.
+     * @param features The String features to parse.
+     * @return The {@link PrivacyManager.Feature} array.
+     */
+    @PrivacyManager.Feature
+    private int[] parseStringFeatures(ReadableArray features) {
+        @PrivacyManager.Feature
+        int[] intFeatures = new int[features.size()];
+
+        for (int i = 0; i < features.size(); i++) {
+            switch (features.getString(i)) {
+                case "FEATURE_NONE":
+                    intFeatures[i] = PrivacyManager.FEATURE_NONE;
+                    break;
+                case "FEATURE_IN_APP_AUTOMATION":
+                    intFeatures[i] = PrivacyManager.FEATURE_IN_APP_AUTOMATION;
+                    break;
+                case "FEATURE_MESSAGE_CENTER":
+                    intFeatures[i] = PrivacyManager.FEATURE_MESSAGE_CENTER;
+                    break;
+                case "FEATURE_PUSH":
+                    intFeatures[i] = PrivacyManager.FEATURE_PUSH;
+                    break;
+                case "FEATURE_CHAT":
+                    intFeatures[i] = PrivacyManager.FEATURE_CHAT;
+                    break;
+                case "FEATURE_ANALYTICS":
+                    intFeatures[i] = PrivacyManager.FEATURE_ANALYTICS;
+                    break;
+                case "FEATURE_TAGS_AND_ATTRIBUTES":
+                    intFeatures[i] = PrivacyManager.FEATURE_TAGS_AND_ATTRIBUTES;
+                    break;
+                case "FEATURE_CONTACTS":
+                    intFeatures[i] = PrivacyManager.FEATURE_CONTACTS;
+                    break;
+                case "FEATURE_LOCATION":
+                    intFeatures[i] = PrivacyManager.FEATURE_LOCATION;
+                    break;
+                default:
+                    intFeatures[i] = PrivacyManager.FEATURE_ALL;
+                    break;
+            }
+        }
+        return intFeatures;
     }
 
 }

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -241,18 +241,6 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Checks if any of the given features is enabled.
-     *
-     * @param features The features to check.
-     * @param promise  The promise.
-     * @return {@code true} if any of the provided features is enabled, otherwise {@code false}.
-     */
-    @ReactMethod
-    public void isFeatureAnyEnabled(ReadableArray features, Promise promise) {
-        promise.resolve(UAirship.shared().getPrivacyManager().isAnyEnabled(parseStringFeatures(features)));
-    }
-
-    /**
      * Checks if the app's notifications are enabled.
      *
      * @param promise The JS promise.

--- a/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const airshipModuleVersionString = @"11.0.2";
+NSString *const airshipModuleVersionString = @"12.0.0";
 
 + (nonnull NSString *)get {
     return airshipModuleVersionString;

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -28,6 +28,8 @@ NSString * const UARCTErrorDomain = @"com.urbanairship.react";
 NSString *const UARCTStatusUnavailable = @"UNAVAILABLE";
 NSString *const UARCTStatusInvalidFeature = @"INVALID_FEATURE";
 NSString *const UARCTErrorDescriptionInvalidFeature = @"Invalid feature, cancelling the action.";
+int const UARCTErrorCodeInvalidFeature = 2;
+
 
 
 #pragma mark -
@@ -101,7 +103,7 @@ RCT_REMAP_METHOD(setEnabledFeatures,
         NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
         NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
         NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
-                                              code:2
+                                              code:UARCTErrorCodeInvalidFeature
                                           userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
         reject(code, errorMessage, error);
     }
@@ -125,7 +127,7 @@ RCT_REMAP_METHOD(enableFeature,
         NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
         NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
         NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
-                                              code:2
+                                              code:UARCTErrorCodeInvalidFeature
                                           userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
         reject(code, errorMessage, error);
     }
@@ -143,7 +145,7 @@ RCT_REMAP_METHOD(disableFeature,
         NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
         NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
         NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
-                                              code:2
+                                              code:UARCTErrorCodeInvalidFeature
                                           userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
         reject(code, errorMessage, error);
     }
@@ -160,7 +162,7 @@ RCT_REMAP_METHOD(isFeatureEnabled,
         NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
         NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
         NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
-                                              code:2
+                                              code:UARCTErrorCodeInvalidFeature
                                           userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
         reject(code, errorMessage, error);
     }

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -87,6 +87,40 @@ RCT_EXPORT_METHOD(enableChannelCreation) {
     [[UAirship channel] enableChannelCreation];
 }
 
+RCT_EXPORT_METHOD(setEnabledFeatures:(NSArray *) features) {
+    [UAirship shared].privacyManager.enabledFeatures = [self parseStringFeatures:features];
+    //[[UAirship shared].privacyManager setEnabledFeatures:[self parseStringFeatures:features]];
+}
+
+RCT_REMAP_METHOD(getEnabledFeatures,
+                 getEnabledFeatures_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(@([UAirship shared].privacyManager.enabledFeatures));
+}
+
+RCT_EXPORT_METHOD(enableFeature:(NSArray *) features) {
+    [[UAirship shared].privacyManager enableFeatures:[self parseStringFeatures:features]];
+}
+
+RCT_EXPORT_METHOD(disableFeature:(NSArray *) features) {
+    [[UAirship shared].privacyManager disableFeatures:[self parseStringFeatures:features]];
+}
+
+RCT_REMAP_METHOD(isFeatureEnabled,
+                 features:(NSArray *)features
+                 isFeatureEnabled_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    [[UAirship shared].privacyManager isEnabled:[self parseStringFeatures:features]];
+}
+
+//TODO Not sure we have this one on iOS
+RCT_REMAP_METHOD(isFeatureAnyEnabled,
+                 features:(NSArray *)features
+                 isFeatureAnyEnabled_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    [[UAirship shared].privacyManager isEnabled:[self parseStringFeatures:features]];
+}
+
 RCT_EXPORT_METHOD(setDataCollectionEnabled:(BOOL)enabled) {
     [[UAirship shared] setDataCollectionEnabled:enabled];
 }
@@ -523,6 +557,35 @@ RCT_REMAP_METHOD(getActiveNotifications,
         }
     }
     return mutations;
+}
+
+-(UAFeatures)parseStringFeatures:(NSArray *)features {
+    UAFeatures convertedFeatures = UAFeaturesNone;
+
+    for (NSString *feature in features) {
+        if ([feature isEqualToString:@"FEATURE_NONE"]) {
+            convertedFeatures |= UAFeaturesNone;
+        } else if ([feature isEqualToString:@"FEATURE_IN_APP_AUTOMATION"]) {
+            convertedFeatures |= UAFeaturesInAppAutomation;
+        } else if ([feature isEqualToString:@"FEATURE_MESSAGE_CENTER"]) {
+            convertedFeatures |= UAFeaturesMessageCenter;
+        } else if ([feature isEqualToString:@"FEATURE_PUSH"]) {
+            convertedFeatures |= UAFeaturesPush;
+        } else if ([feature isEqualToString:@"FEATURE_CHAT"]) {
+            convertedFeatures |= UAFeaturesChat;
+        } else if ([feature isEqualToString:@"FEATURE_ANALYTICS"]) {
+            convertedFeatures |= UAFeaturesAnalytics;
+        } else if ([feature isEqualToString:@"FEATURE_TAGS_AND_ATTRIBUTES"]) {
+            convertedFeatures |= UAFeaturesTagsAndAttributes;
+        } else if ([feature isEqualToString:@"FEATURE_CONTACTS"]) {
+            convertedFeatures |= UAFeaturesContacts;
+        } else if ([feature isEqualToString:@"FEATURE_LOCATION"]) {
+            convertedFeatures |= UAFeaturesLocation;
+        } else {
+            convertedFeatures |= UAFeaturesAll;
+        }
+    }
+    return convertedFeatures;
 }
 
 @end

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -113,22 +113,6 @@ RCT_REMAP_METHOD(isFeatureEnabled,
     [[UAirship shared].privacyManager isEnabled:[self parseStringFeatures:features]];
 }
 
-//TODO Not sure we have this one on iOS
-RCT_REMAP_METHOD(isFeatureAnyEnabled,
-                 features:(NSArray *)features
-                 isFeatureAnyEnabled_resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-    [[UAirship shared].privacyManager isEnabled:[self parseStringFeatures:features]];
-}
-
-RCT_EXPORT_METHOD(setDataCollectionEnabled:(BOOL)enabled) {
-    [[UAirship shared] setDataCollectionEnabled:enabled];
-}
-
-RCT_EXPORT_METHOD(setPushTokenRegistrationEnabled:(BOOL)enabled) {
-    [[UAirship push] setPushTokenRegistrationEnabled:enabled];
-}
-
 RCT_REMAP_METHOD(isUserNotificationsEnabled,
                  isUserNotificationsEnabled_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
@@ -150,20 +134,6 @@ RCT_REMAP_METHOD(enableUserPushNotifications,
     [[UAirship push] enableUserPushNotifications:^(BOOL success) {
         resolve(@(success));
     }];
-}
-
-RCT_REMAP_METHOD(isDataCollectionEnabled,
-                 isDataCollectionEnabled_resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-
-    resolve(@([UAirship shared].isDataCollectionEnabled));
-}
-
-RCT_REMAP_METHOD(isPushTokenRegistrationEnabled,
-                 isPushTokenRegistrationEnabled_resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-
-    resolve(@([UAirship push].pushTokenRegistrationEnabled));
 }
 
 RCT_EXPORT_METHOD(setNamedUser:(NSString *)namedUser) {

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -26,6 +26,8 @@
 NSString * const UARCTErrorDomain = @"com.urbanairship.react";
 
 NSString *const UARCTStatusUnavailable = @"UNAVAILABLE";
+NSString *const UARCTStatusInvalidFeature = @"INVALID_FEATURE";
+NSString *const UARCTErrorDescriptionInvalidFeature = @"Invalid feature, cancelling the action.";
 
 
 #pragma mark -
@@ -87,29 +89,81 @@ RCT_EXPORT_METHOD(enableChannelCreation) {
     [[UAirship channel] enableChannelCreation];
 }
 
-RCT_EXPORT_METHOD(setEnabledFeatures:(NSArray *) features) {
-    [UAirship shared].privacyManager.enabledFeatures = [self parseStringFeatures:features];
+RCT_REMAP_METHOD(setEnabledFeatures,
+                 features:(NSArray *) features
+                 setEnabledFeatures_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+   
+    if ([self isValidFeature:features]) {
+        [UAirship shared].privacyManager.enabledFeatures = [self stringToFeature:features];
+        resolve(@(YES));
+    } else {
+        NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
+        NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
+        NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
+                                              code:2
+                                          userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
+        reject(code, errorMessage, error);
+    }
 }
 
 RCT_REMAP_METHOD(getEnabledFeatures,
                  getEnabledFeatures_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve(@([UAirship shared].privacyManager.enabledFeatures));
+    resolve([self featureToString:[UAirship shared].privacyManager.enabledFeatures]);
 }
 
-RCT_EXPORT_METHOD(enableFeature:(NSArray *) features) {
-    [[UAirship shared].privacyManager enableFeatures:[self parseStringFeatures:features]];
+RCT_REMAP_METHOD(enableFeature,
+                 features:(NSArray *) features
+                 enableFeature_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    if ([self isValidFeature:features]) {
+        [[UAirship shared].privacyManager enableFeatures:[self stringToFeature:features]];
+        resolve(@(YES));
+    } else {
+        NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
+        NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
+        NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
+                                              code:2
+                                          userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
+        reject(code, errorMessage, error);
+    }
 }
 
-RCT_EXPORT_METHOD(disableFeature:(NSArray *) features) {
-    [[UAirship shared].privacyManager disableFeatures:[self parseStringFeatures:features]];
+RCT_REMAP_METHOD(disableFeature,
+                 features:(NSArray *) features
+                 disableFeature_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    if ([self isValidFeature:features]) {
+        [[UAirship shared].privacyManager disableFeatures:[self stringToFeature:features]];
+        resolve(@(YES));
+    } else {
+        NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
+        NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
+        NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
+                                              code:2
+                                          userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
+        reject(code, errorMessage, error);
+    }
 }
 
 RCT_REMAP_METHOD(isFeatureEnabled,
                  features:(NSArray *)features
                  isFeatureEnabled_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve(@([[UAirship shared].privacyManager isEnabled:[self parseStringFeatures:features]]));
+    
+    if ([self isValidFeature:features]) {
+        resolve(@([[UAirship shared].privacyManager isEnabled:[self stringToFeature:features]]));
+    } else {
+        NSString *code = [NSString stringWithFormat:UARCTStatusInvalidFeature];
+        NSString *errorMessage = [NSString stringWithFormat:UARCTErrorDescriptionInvalidFeature];
+        NSError *error =  [NSError errorWithDomain:UARCTErrorDomain
+                                              code:2
+                                          userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
+        reject(code, errorMessage, error);
+    }
 }
 
 RCT_REMAP_METHOD(isUserNotificationsEnabled,
@@ -528,33 +582,70 @@ RCT_REMAP_METHOD(getActiveNotifications,
     return mutations;
 }
 
--(UAFeatures)parseStringFeatures:(NSArray *)features {
-    UAFeatures convertedFeatures = UAFeaturesNone;
+- (BOOL)isValidFeature:(NSArray *)features {
+    if (!features || [features count] == 0) {
+        return NO;
+    }
+    NSDictionary *authorizedFeatures = [self authorizedFeatures];
 
     for (NSString *feature in features) {
-        if ([feature isEqualToString:@"FEATURE_NONE"]) {
-            convertedFeatures |= UAFeaturesNone;
-        } else if ([feature isEqualToString:@"FEATURE_IN_APP_AUTOMATION"]) {
-            convertedFeatures |= UAFeaturesInAppAutomation;
-        } else if ([feature isEqualToString:@"FEATURE_MESSAGE_CENTER"]) {
-            convertedFeatures |= UAFeaturesMessageCenter;
-        } else if ([feature isEqualToString:@"FEATURE_PUSH"]) {
-            convertedFeatures |= UAFeaturesPush;
-        } else if ([feature isEqualToString:@"FEATURE_CHAT"]) {
-            convertedFeatures |= UAFeaturesChat;
-        } else if ([feature isEqualToString:@"FEATURE_ANALYTICS"]) {
-            convertedFeatures |= UAFeaturesAnalytics;
-        } else if ([feature isEqualToString:@"FEATURE_TAGS_AND_ATTRIBUTES"]) {
-            convertedFeatures |= UAFeaturesTagsAndAttributes;
-        } else if ([feature isEqualToString:@"FEATURE_CONTACTS"]) {
-            convertedFeatures |= UAFeaturesContacts;
-        } else if ([feature isEqualToString:@"FEATURE_LOCATION"]) {
-            convertedFeatures |= UAFeaturesLocation;
-        } else {
-            convertedFeatures |= UAFeaturesAll;
+        if (![authorizedFeatures objectForKey:feature]) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+- (UAFeatures)stringToFeature:(NSArray *)features {
+    NSDictionary *authorizedFeatures = [self authorizedFeatures];
+    
+    NSNumber* objectFeature = authorizedFeatures[[features objectAtIndex:0]];
+    UAFeatures convertedFeatures = [objectFeature longValue];
+    
+    if ([features count] > 1) {
+        int i;
+        for (i = 1; i < [features count]; i++) {
+            NSNumber* objectFeature = authorizedFeatures[[features objectAtIndex:i]];
+            convertedFeatures |= [objectFeature longValue];
         }
     }
     return convertedFeatures;
+}
+
+- (NSArray *)featureToString:(UAFeatures)features {
+    NSMutableArray *convertedFeatures = [[NSMutableArray alloc] init];
+
+    NSDictionary *authorizedFeatures = [self authorizedFeatures];
+    
+    if (features == UAFeaturesAll) {
+        [convertedFeatures addObject:@"FEATURE_ALL"];
+    } else if (features == UAFeaturesNone) {
+        [convertedFeatures addObject:@"FEATURE_NONE"];
+    } else {
+        for (NSString *feature in authorizedFeatures) {
+            NSNumber *objectFeature = authorizedFeatures[feature];
+            long longFeature = [objectFeature longValue];
+            if ((longFeature & features) && (longFeature != UAFeaturesAll)) {
+                [convertedFeatures addObject:feature];
+            }
+        }
+    }
+    return convertedFeatures;
+}
+
+- (NSDictionary *)authorizedFeatures {
+    NSMutableDictionary *authorizedFeatures = [[NSMutableDictionary alloc] init];
+    [authorizedFeatures setValue:@(UAFeaturesNone) forKey:@"FEATURE_NONE"];
+    [authorizedFeatures setValue:@(UAFeaturesInAppAutomation) forKey:@"FEATURE_IN_APP_AUTOMATION"];
+    [authorizedFeatures setValue:@(UAFeaturesMessageCenter) forKey:@"FEATURE_MESSAGE_CENTER"];
+    [authorizedFeatures setValue:@(UAFeaturesPush) forKey:@"FEATURE_PUSH"];
+    [authorizedFeatures setValue:@(UAFeaturesChat) forKey:@"FEATURE_CHAT"];
+    [authorizedFeatures setValue:@(UAFeaturesAnalytics) forKey:@"FEATURE_ANALYTICS"];
+    [authorizedFeatures setValue:@(UAFeaturesTagsAndAttributes) forKey:@"FEATURE_TAGS_AND_ATTRIBUTES"];
+    [authorizedFeatures setValue:@(UAFeaturesContacts) forKey:@"FEATURE_CONTACTS"];
+    [authorizedFeatures setValue:@(UAFeaturesLocation) forKey:@"FEATURE_LOCATION"];
+    [authorizedFeatures setValue:@(UAFeaturesAll) forKey:@"FEATURE_ALL"];
+    return authorizedFeatures;
 }
 
 @end

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -89,7 +89,6 @@ RCT_EXPORT_METHOD(enableChannelCreation) {
 
 RCT_EXPORT_METHOD(setEnabledFeatures:(NSArray *) features) {
     [UAirship shared].privacyManager.enabledFeatures = [self parseStringFeatures:features];
-    //[[UAirship shared].privacyManager setEnabledFeatures:[self parseStringFeatures:features]];
 }
 
 RCT_REMAP_METHOD(getEnabledFeatures,
@@ -110,7 +109,7 @@ RCT_REMAP_METHOD(isFeatureEnabled,
                  features:(NSArray *)features
                  isFeatureEnabled_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    [[UAirship shared].privacyManager isEnabled:[self parseStringFeatures:features]];
+    resolve(@([[UAirship shared].privacyManager isEnabled:[self parseStringFeatures:features]]));
 }
 
 RCT_REMAP_METHOD(isUserNotificationsEnabled,

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -419,50 +419,6 @@ export class UrbanAirship {
   }
 
   /**
-   * Global data collection flag. Enabled by default, unless `dataCollectionOptInEnabled`
-   * is set to `YES` in AirshipConfig.plist on iOS, and `true` in airshipconfig.properties on Android.
-   * When disabled, the device will stop collecting and sending data for named user, events,
-   * tags, attributes, associated identifiers, and location from the device.
-   *
-   * Push notifications will continue to work only if `UrbanAirship.setPushTokenRegistrationEnabled`
-   * has been explicitly set to `true`, otherwise it will default to the current state of `isDataCollectionEnabled`.
-   *
-   * @note To disable by default, set the `dataCollectionOptInEnabled` flag to `YES` in AirshipConfig.plist on iOS, and `true` in airshipconfig.properties on Android.
-   * @param enabled true to enable data collection, false to disable.
-   */
-  static setDataCollectionEnabled(enabled: boolean) {
-    UrbanAirshipModule.setDataCollectionEnabled(enabled);
-  }
-
-  /**
-   * Checks if data collection is enabled or not.
-   *
-   * @return A promise with the result.
-   */
-  static isDataCollectionEnabled(): Promise<boolean> {
-    return UrbanAirshipModule.isDataCollectionEnabled();
-  }
-
-  /**
-   * Enables/disables sending the device token during channel registration.
-   * Defaults to `UrbanAirship.isDataCollectionEnabled`. If set to `false`, the app will not be able to receive push
-   * notifications.
-   * @param enabled true to enable push token registration, false to disable.
-   */
-  static setPushTokenRegistrationEnabled(enabled: boolean) {
-    UrbanAirshipModule.setPushTokenRegistrationEnabled(enabled);
-  }
-
-  /**
-   * Checks if push token registration is enabled or not.
-   *
-   * @return A promise with the result.
-   */
-  static isPushTokenRegistrationEnabled(): Promise<boolean> {
-    return UrbanAirshipModule.isPushTokenRegistrationEnabled();
-  }
-
-  /**
    * Enables user notifications.
    *
    * @return A promise that returns true if enablement was authorized

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -338,6 +338,19 @@ export interface NotificationConfigAndroid {
   defaultChannelId?: string;
 }
 
+export enum Feature {
+  FEATURE_NONE = "FEATURE_NONE",
+  FEATURE_IN_APP_AUTOMATION = "FEATURE_IN_APP_AUTOMATION",
+  FEATURE_MESSAGE_CENTER = "FEATURE_MESSAGE_CENTER",
+  FEATURE_PUSH = "FEATURE_PUSH",
+  FEATURE_CHAT = "FEATURE_CHAT",
+  FEATURE_ANALYTICS = "FEATURE_ANALYTICS",
+  FEATURE_TAGS_AND_ATTRIBUTES = "FEATURE_TAGS_AND_ATTRIBUTES",
+  FEATURE_CONTACTS = "FEATURE_CONTACTS",
+  FEATURE_LOCATION = "FEATURE_LOCATION",
+  FEATURE_ALL = "FEATURE_ALL"
+}
+
 /**
 * The main Airship API.
 */
@@ -368,6 +381,41 @@ export class UrbanAirship {
    */
   static isUserNotificationsEnabled(): Promise<boolean> {
     return UrbanAirshipModule.isUserNotificationsEnabled();
+  }
+
+  // TODO Comment all of these
+  static setEnabledFeatures(features: Feature[]) {
+    UrbanAirshipModule.setEnabledFeatures(features);
+  }
+
+  static getEnabledFeatures(): Promise<number> {
+    return UrbanAirshipModule.getEnabledFeatures();
+  }
+
+  static enableFeature(features: Feature[]) {
+    UrbanAirshipModule.enableFeature(features);
+  }
+
+  static disableFeature(features: Feature[]) {
+      UrbanAirshipModule.disableFeature(features);
+  }
+
+  /**
+   * Checks if a given feature is enabled or not.
+   *
+   * @return A promise with the result.
+   */
+  static isFeatureEnabled(features: Feature[]): Promise<boolean> {
+    return UrbanAirshipModule.isFeatureEnabled(features);
+  }
+
+  /**
+   * Checks if any of the given features is enabled or not.
+   *
+   * @return A promise with the result.
+   */
+  static isFeatureAnyEnabled(features: Feature[]): Promise<boolean> {
+    return UrbanAirshipModule.isFeatureAnyEnabled(features);
   }
 
   /**

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -320,6 +320,32 @@ function convertEventEnum(type: EventType): string {
   throw new Error("Invalid event name: " + type);
 }
 
+function convertFeatureEnum(feature: String): Feature {
+  if (feature == "FEATURE_NONE") {
+    return Feature.FEATURE_NONE
+  } else if (feature == "FEATURE_IN_APP_AUTOMATION") {
+    return Feature.FEATURE_IN_APP_AUTOMATION
+  } else if (feature == "FEATURE_MESSAGE_CENTER") {
+    return Feature.FEATURE_MESSAGE_CENTER
+  } else if (feature == "FEATURE_PUSH") {
+    return Feature.FEATURE_PUSH
+  } else if (feature == "FEATURE_CHAT") {
+    return Feature.FEATURE_CHAT
+  } else if (feature == "FEATURE_ANALYTICS") {
+    return Feature.FEATURE_ANALYTICS
+  } else if (feature == "FEATURE_TAGS_AND_ATTRIBUTES") {
+    return Feature.FEATURE_TAGS_AND_ATTRIBUTES
+  } else if (feature == "FEATURE_CONTACTS") {
+    return Feature.FEATURE_CONTACTS
+  } else if (feature == "FEATURE_LOCATION") {
+    return Feature.FEATURE_LOCATION
+  } else if (feature == "FEATURE_ALL") {
+    return Feature.FEATURE_ALL
+  }
+
+  throw new Error("Invalid feature name: " + feature);
+}
+
 /**
  * Android notification config.
  */
@@ -400,12 +426,22 @@ export class UrbanAirship {
   }
 
   /**
-   * Gets a String array with the enabled features.
+   * Gets a Feature array with the enabled features.
    * 
-   * @return A promise that returns the enabled features as a String array.
+   * @return A promise that returns the enabled features as a Feature array.
    */
-  static getEnabledFeatures(): Promise<String[]> {
-    return UrbanAirshipModule.getEnabledFeatures();
+  static getEnabledFeatures(): Promise<Feature[]> {
+    return new Promise((resolve, reject) => {
+      UrbanAirshipModule.getEnabledFeatures().then((features: String[]) => {
+        var convertedFeatures: Feature[] = new Array();        
+        for (const feature of features){
+          convertedFeatures.push(convertFeatureEnum(feature));
+        }
+        resolve(convertedFeatures);
+      }), (error: Error) => {
+        reject(error);
+      };
+    });
   }
 
   /**

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -383,19 +383,41 @@ export class UrbanAirship {
     return UrbanAirshipModule.isUserNotificationsEnabled();
   }
 
-  // TODO Comment all of these
+  /**
+   * Sets the SDK features that will be enabled. The rest of the features will be disabled.
+   * 
+   * If all features are disabled the SDK will not make any network requests or collect data.
+   *
+   * @note All features are enabled by default.
+   * @param feature An array of `Features` to enable.
+   */
   static setEnabledFeatures(features: Feature[]) {
     UrbanAirshipModule.setEnabledFeatures(features);
   }
 
+  /**
+   * Gets a flag number representing the enabled features.
+   * 
+   * @return A promise that returns the enabled features as a flag `number`.
+   */
   static getEnabledFeatures(): Promise<number> {
     return UrbanAirshipModule.getEnabledFeatures();
   }
 
+  /**
+   * Enables one or many features.
+   *
+   * @param feature An array of `Feature` to enable.
+   */
   static enableFeature(features: Feature[]) {
     UrbanAirshipModule.enableFeature(features);
   }
 
+  /**
+   * Disables one or many features.
+   *
+   * @param feature An array of `Feature` to disable.
+   */
   static disableFeature(features: Feature[]) {
       UrbanAirshipModule.disableFeature(features);
   }
@@ -403,19 +425,10 @@ export class UrbanAirship {
   /**
    * Checks if a given feature is enabled or not.
    *
-   * @return A promise with the result.
+   * @return A promise that returns true if the features are enabled, false otherwise.
    */
   static isFeatureEnabled(features: Feature[]): Promise<boolean> {
     return UrbanAirshipModule.isFeatureEnabled(features);
-  }
-
-  /**
-   * Checks if any of the given features is enabled or not.
-   *
-   * @return A promise with the result.
-   */
-  static isFeatureAnyEnabled(features: Feature[]): Promise<boolean> {
-    return UrbanAirshipModule.isFeatureAnyEnabled(features);
   }
 
   /**

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -338,6 +338,9 @@ export interface NotificationConfigAndroid {
   defaultChannelId?: string;
 }
 
+/**
+ * Enum of authorized Features.
+ */
 export enum Feature {
   FEATURE_NONE = "FEATURE_NONE",
   FEATURE_IN_APP_AUTOMATION = "FEATURE_IN_APP_AUTOMATION",
@@ -390,17 +393,18 @@ export class UrbanAirship {
    *
    * @note All features are enabled by default.
    * @param feature An array of `Features` to enable.
+   * @return A promise that returns true if the enablement was authorized.
    */
-  static setEnabledFeatures(features: Feature[]) {
-    UrbanAirshipModule.setEnabledFeatures(features);
+  static setEnabledFeatures(features: Feature[]): Promise<boolean> {
+    return UrbanAirshipModule.setEnabledFeatures(features);
   }
 
   /**
-   * Gets a flag number representing the enabled features.
+   * Gets a String array with the enabled features.
    * 
-   * @return A promise that returns the enabled features as a flag `number`.
+   * @return A promise that returns the enabled features as a String array.
    */
-  static getEnabledFeatures(): Promise<number> {
+  static getEnabledFeatures(): Promise<String[]> {
     return UrbanAirshipModule.getEnabledFeatures();
   }
 
@@ -408,18 +412,20 @@ export class UrbanAirship {
    * Enables one or many features.
    *
    * @param feature An array of `Feature` to enable.
+   * @return A promise that returns true if the enablement was authorized.
    */
-  static enableFeature(features: Feature[]) {
-    UrbanAirshipModule.enableFeature(features);
+  static enableFeature(features: Feature[]): Promise<boolean> {
+    return UrbanAirshipModule.enableFeature(features);
   }
 
   /**
    * Disables one or many features.
    *
    * @param feature An array of `Feature` to disable.
+   * @return A promise that returns true if the disablement was authorized.
    */
-  static disableFeature(features: Feature[]) {
-      UrbanAirshipModule.disableFeature(features);
+  static disableFeature(features: Feature[]): Promise<boolean> {
+    return UrbanAirshipModule.disableFeature(features);
   }
 
   /**

--- a/urbanairship-react-native/package.json
+++ b/urbanairship-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "11.0.2",
+  "version": "12.0.0",
   "description": "Airship plugin for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-react-native/urbanairship-react-native.podspec
+++ b/urbanairship-react-native/urbanairship-react-native.podspec
@@ -13,6 +13,6 @@ require "json"
   s.source       = { :git => "https://github.com/urbanairship/react-native-module.git", :tag => "{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
   s.dependency "React-Core"
-  s.dependency "Airship", "14.4.2"
+  s.dependency "Airship", "14.5.1"
 
 end


### PR DESCRIPTION
### What do these changes do?
Updates the Airship SDKs version, expose the new privacy manager methods and remove the old data collection methods

### Why are these changes necessary?
To replace the data collection methods with the privacy manager

### How did you verify these changes?
Tested the methods by logging the results in the sample.
The methods work fine on both Android and iOS.

#### Verification Screenshots:

### Anything else a reviewer should know?
We will need to add some example of use in the doc
