### PR TITLE
[MOBILE-2396] fix message view touch events in example

### DIFF
--- a/example/screens/MessageScreen.js
+++ b/example/screens/MessageScreen.js
@@ -83,11 +83,13 @@ export default class MessageScreen extends React.Component {
           onLoadError={this.failedLoading}
           style={{ flex: 1 }}
         />
+        {this.state.animating &&
         <View style={styles.loadingIndicator}>
           <ActivityIndicator size="large"
             animating={this.state.animating}
           />
         </View>
+        }
       </View>
     );
   }


### PR DESCRIPTION
The loading indicator view in MessageScreen is blocking touches in our example code, even when it's not visible. This change makes sure that the view is only rendered if it is currently animating. Tested manually in the iOS simulator with the sample app, and verified that scrolling and buttons work as expected.