### PR TITLE
[MOBILE-2418] fix example README

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -4,7 +4,7 @@ A basic sample application that integrates the Airship React Native module.
 
 ## Setup
 
-1) Install modules: Run `npm install` in repository root
+1) Install modules: Run `yarn` in repository root
 
 ### iOS
 


### PR DESCRIPTION
We still had a reference to `npm install` in the example README, which is confusing and results in errors. The example is connected to our yarn workspace, and so you have to use yarn to build the modules.