### PR TITLE
Expose `addTags` and `removeTags` methods

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -298,6 +298,18 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * Adds multiple channel tags.
+     *
+     * @param tags An array of tags to add.
+     */
+    @ReactMethod
+    public void addTags(ReadableArray tags) {
+        if (tags.length > 0) {
+            UAirship.shared().getChannel().editTags().addTags(tags).apply();
+        }
+    }
+
+    /**
      * Removes a channel tag.
      *
      * @param tag The tag to remove.
@@ -306,6 +318,18 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     public void removeTag(String tag) {
         if (tag != null) {
             UAirship.shared().getChannel().editTags().removeTag(tag).apply();
+        }
+    }
+
+    /**
+     * Removes multiple channel tags.
+     *
+     * @param tags An array of tags to remove.
+     */
+    @ReactMethod
+    public void removeTags(ReadableArray tags) {
+        if (tags.length > 0) {
+            UAirship.shared().getChannel().editTags().removeTags(tags).apply();
         }
     }
 

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -150,9 +150,23 @@ RCT_EXPORT_METHOD(addTag:(NSString *)tag) {
     }
 }
 
+RCT_EXPORT_METHOD(addTags:(NSArray *)tags) {
+    if (tags) {
+        [[UAirship channel] addTags:tags];
+        [[UAirship channel] updateRegistration];
+    }
+}
+
 RCT_EXPORT_METHOD(removeTag:(NSString *)tag) {
     if (tag) {
         [[UAirship channel] removeTag:tag];
+        [[UAirship channel] updateRegistration];
+    }
+}
+
+RCT_EXPORT_METHOD(removeTags:(NSArray *)tags) {
+    if (tags) {
+        [[UAirship channel] removeTags:tags];
         [[UAirship channel] updateRegistration];
     }
 }

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -470,12 +470,30 @@ export class UrbanAirship {
   }
 
   /**
+   * Adds multiple channel tags.
+   *
+   * @param tags An array of channel tags.
+   */
+  static addTags(tags: Array<string>) {
+    UrbanAirshipModule.addTags(tags);
+  }
+
+  /**
    * Removes a channel tag.
    *
    * @param tag A channel tag.
    */
   static removeTag(tag: string) {
     UrbanAirshipModule.removeTag(tag);
+  }
+
+  /**
+   * Removes multiple channel tags.
+   *
+   * @param tags An array of channel tags.
+   */
+  static removeTags(tags: Array<string>) {
+    UrbanAirshipModule.removeTags(tags);
   }
 
   /**


### PR DESCRIPTION
### What do these changes do?
These changes expose the `addTags` and `removeTags` methods that both the iOS and Android SDK support

### Why are these changes necessary?
The RN library calls `updateRegistration` after each `addTag` - this is problematic when onboarding new users where bulk subscriptions are necessary.

### How did you verify these changes?
These changes are largely copy-paste and making a change from `addTag` to `addTags`. I haven't built them to verify just yet