### PR TITLE
[MOBILE-2482] isUserNotificationsOptedIn discrepancy between iOS and Android in React Native SDK Issue

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -3,6 +3,7 @@
 package com.urbanairship.reactnative;
 
 import android.app.Activity;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
@@ -13,6 +14,7 @@ import android.service.notification.StatusBarNotification;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationManagerCompat;
 
 import com.facebook.react.bridge.Arguments;
@@ -291,6 +293,32 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void isUserNotificationsOptedIn(Promise promise) {
         promise.resolve(UAirship.shared().getPushManager().isOptIn());
+    }
+
+    /**
+     * Checks if the app's notifications are enabled at the system level.
+     *
+     * @param promise The JS promise.
+     */
+    @ReactMethod
+    public void isSystemNotificationsEnabledForApp(Promise promise) {
+        promise.resolve(NotificationManagerCompat.from(getReactApplicationContext()).areNotificationsEnabled());
+    }
+
+    @ReactMethod
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void getNotificationChannelStatus(String channelId, Promise promise) {
+        NotificationManager manager = (NotificationManager) getReactApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationChannel channel = manager.getNotificationChannel(channelId);
+        if (channel == null) {
+            promise.resolve("unknown");
+        } else {
+            if (channel.getImportance() != NotificationManager.IMPORTANCE_NONE) {
+                promise.resolve("enabled");
+            } else {
+                promise.resolve("disabled");
+            }
+        }
     }
 
     /**

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -198,7 +198,6 @@ RCT_REMAP_METHOD(isUserNotificationsOptedIn,
             UA_LTRACE(@"Opted out: push is disabled");
             optedIn = NO;
         }
-
         resolve(@(optedIn));
 }
 

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -193,6 +193,11 @@ RCT_REMAP_METHOD(isUserNotificationsOptedIn,
             UA_LTRACE(@"Opted out: no authorized notification settings");
             optedIn = NO;
         }
+    
+        if (![[UAirship shared].privacyManager isEnabled:UAFeaturesPush]) {
+            UA_LTRACE(@"Opted out: push is disabled");
+            optedIn = NO;
+        }
 
         resolve(@(optedIn));
 }

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -178,6 +178,13 @@ RCT_REMAP_METHOD(isUserNotificationsEnabled,
 RCT_REMAP_METHOD(isUserNotificationsOptedIn,
                  isUserNotificationsOptedIn_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
+    BOOL optedIn = [[UAirship push] userPushNotificationsEnabled];
+    resolve(@(optedIn));
+}
+
+RCT_REMAP_METHOD(isSystemNotificationsEnabledForApp,
+                 isSystemNotificationsEnabledForApp_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
     BOOL optedIn = [UAirship push].authorizedNotificationSettings != 0;
     resolve(@(optedIn));
 }
@@ -185,7 +192,6 @@ RCT_REMAP_METHOD(isUserNotificationsOptedIn,
 RCT_REMAP_METHOD(enableUserPushNotifications,
                  enableUserPushNotifications_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-
     [[UAirship push] enableUserPushNotifications:^(BOOL success) {
         resolve(@(success));
     }];

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -178,8 +178,23 @@ RCT_REMAP_METHOD(isUserNotificationsEnabled,
 RCT_REMAP_METHOD(isUserNotificationsOptedIn,
                  isUserNotificationsOptedIn_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    BOOL optedIn = [[UAirship push] userPushNotificationsEnabled];
-    resolve(@(optedIn));
+        BOOL optedIn = YES;
+        if (![UAirship push].deviceToken) {
+            UA_LTRACE(@"Opted out: missing device token");
+            optedIn = NO;
+        }
+
+        if (![UAirship push].userPushNotificationsEnabled) {
+            UA_LTRACE(@"Opted out: user push notifications disabled");
+            optedIn = NO;
+        }
+
+        if (![UAirship push].authorizedNotificationSettings) {
+            UA_LTRACE(@"Opted out: no authorized notification settings");
+            optedIn = NO;
+        }
+
+        resolve(@(optedIn));
 }
 
 RCT_REMAP_METHOD(isSystemNotificationsEnabledForApp,

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -508,6 +508,29 @@ export class UrbanAirship {
     return UrbanAirshipModule.isUserNotificationsOptedIn();
   }
 
+   /**
+   * Checks if app notifications are enabled at a system level or not. Its possible to have `userNotificationsEnabled`
+   * but app notifications being disabled if the user opted out of notifications.
+   *
+   * @return A promise with the result.
+   */
+  static isSystemNotificationsEnabledForApp(): Promise<boolean> {
+    return UrbanAirshipModule.isSystemNotificationsEnabledForApp();
+  }
+
+  /**
+   * Gets the status of the specified Notification Channel.
+   * This method is only supported on Android. iOS will no-op.
+   *
+   * @param channel The channel's name.
+   * @return A promise with the result.
+   */
+  static getNotificationChannelStatus(channel: string) {
+    if (Platform.OS == 'android') {
+      return UrbanAirshipModule.getNotificationChannelStatus(channel);
+    }
+  }
+
   /**
    * Sets the named user.
    *

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -520,14 +520,14 @@ export class UrbanAirship {
 
   /**
    * Gets the status of the specified Notification Channel.
-   * This method is only supported on Android. iOS will no-op.
+   * This method is only supported on Android. iOS will throw an error.
    *
    * @param channel The channel's name.
    * @return A promise with the result.
    */
   static getNotificationChannelStatus(channel: string): Promise<string> {
     if (Platform.OS != 'android') {
-      console.log("This feature is not supported on this platform.");
+      throw new Error("This method is only supported on Android devices.");
     }
     return UrbanAirshipModule.getNotificationChannelStatus(channel);
   }

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -525,10 +525,11 @@ export class UrbanAirship {
    * @param channel The channel's name.
    * @return A promise with the result.
    */
-  static getNotificationChannelStatus(channel: string) {
-    if (Platform.OS == 'android') {
-      return UrbanAirshipModule.getNotificationChannelStatus(channel);
+  static getNotificationChannelStatus(channel: string): Promise<string> {
+    if (Platform.OS != 'android') {
+      console.log("This feature is not supported on this platform.");
     }
+    return UrbanAirshipModule.getNotificationChannelStatus(channel);
   }
 
   /**


### PR DESCRIPTION
### What do these changes do?
 - Update the iOS method isUserNotificationsOptedIn to use the UAPush method. 

- Add a new method isSystemNotificationsEnabledForApp that checks for the notification manager on android and authorized types on iOS.

- Add another method that for Android getNotificationChannelStatus(channel) that returns enabled, disabled, and unknown where unknown is returned if it's not yet created.

### Why are these changes necessary?
Because this presents a problem for Axios React Native Implementation noted as the unified call essentially returns a different result between iOS and Android. Axios has built logic into their app that requires App-Level notification opt-in information that we currently do not expose for Android. 

### How did you verify these changes?
Running with the sample app and testing the methods
