### PR TITLE
fix(android): setup android:exported explicitly on all activities

### DIFF
--- a/urbanairship-react-native/android/src/main/AndroidManifest.xml
+++ b/urbanairship-react-native/android/src/main/AndroidManifest.xml
@@ -10,14 +10,17 @@
         <activity
             android:name="com.urbanairship.reactnative.CustomMessageCenterActivity"
             android:label="@string/ua_message_center_title"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.urbanairship.VIEW_RICH_PUSH_INBOX" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
 
-        <activity android:name="com.urbanairship.reactnative.CustomMessageActivity">
+        <activity
+            android:name="com.urbanairship.reactnative.CustomMessageActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.urbanairship.VIEW_RICH_PUSH_MESSAGE" />
                 <data android:scheme="message" />


### PR DESCRIPTION
### What do these changes do?
explicitly setup android:exported on activity tags.

### Why are these changes necessary?
Targeting android 31+ requires all the activities and services to be explicit about android:exported prop.

### How did you verify these changes?
I changed them directly on node_modules and my build went through and the sdk was functional.

