### PR TITLE
[MOBILE-2597] Locale overwrite missing

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -53,6 +53,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.urbanairship.actions.ActionResult.STATUS_ACTION_NOT_FOUND;
@@ -857,6 +858,35 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
                 .edit()
                 .putBoolean(AUTO_LAUNCH_MESSAGE_CENTER, enabled)
                 .apply();
+    }
+
+    /**
+     * Overriding the locale.
+     *
+     * @param localeIdentifier The locale identifier.
+     */
+    @ReactMethod
+    public void setCurrentLocale(String localeIdentifier) {
+        UAirship.shared().setLocaleOverride(new Locale(localeIdentifier));
+    }
+
+    /**
+     * Getting the locale currently used by Airship.
+     *
+     */
+    @ReactMethod
+    public void getCurrentLocale(Promise promise) {
+        Locale airshipLocale = UAirship.shared().getLocale();
+        promise.resolve(airshipLocale.getLanguage());
+    }
+
+    /**
+     * Resets the current locale.
+     *
+     */
+    @ReactMethod
+    public void clearLocale() {
+        UAirship.shared().setLocaleOverride(null);
     }
 
     /**

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -569,6 +569,21 @@ RCT_EXPORT_METHOD(setAutoLaunchDefaultMessageCenter:(BOOL)enabled) {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:UARCTAutoLaunchMessageCenterKey];
 }
 
+RCT_EXPORT_METHOD(setCurrentLocale:(NSString *)localeIdentifier) {
+    [UAirship.shared.localeManager setCurrentLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier]];
+}
+
+RCT_REMAP_METHOD(getCurrentLocale,
+                 getCurrentLocale_resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    NSLocale *airshipLocale = [[UAirship shared].localeManager currentLocale];
+    resolve(airshipLocale.localeIdentifier);
+}
+
+RCT_EXPORT_METHOD(clearLocale) {
+    [[UAirship shared].localeManager clearLocale];
+}
+
 RCT_EXPORT_METHOD(clearNotifications) {
     [[UNUserNotificationCenter currentNotificationCenter] removeAllDeliveredNotifications];
 }

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -918,6 +918,31 @@ export class UrbanAirship {
   }
 
   /**
+   * Overriding the locale.
+   *
+   * @param localeIdentifier The locale identifier.
+   */
+  static setCurrentLocale(localeIdentifier: String) {
+    UrbanAirshipModule.setCurrentLocale(localeIdentifier);
+  }
+
+  /**
+   * Getting the locale currently used by Airship.
+   *
+   */
+  static getCurrentLocale(): Promise<String> {
+    return UrbanAirshipModule.getCurrentLocale();
+  }
+
+  /**
+   * Resets the current locale.
+   *
+   */
+  static clearLocale() {
+    UrbanAirshipModule.clearLocale();
+  }
+
+  /**
    * Gets all the active notifications for the application.
    * Supported on Android Marshmallow (23)+ and iOS 10+.
    *


### PR DESCRIPTION
### What do these changes do?
Add missing local everride method:
- `setCurrentLocale(localeIdentifier)`
- `getCurrentLocale()`
- `clearLocale()`

### Why are these changes necessary?
Fix this ticket issue
https://github.com/urbanairship/react-native-module/issues/358

### How did you verify these changes?
Use sample app to test it

