### PR TITLE
[MOBILE-2633] Release 13.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 ## Version 13.0.1 - November 5, 2021
 Patch release that fixes preferences resetting when upgrading to SDK 15/16. This update will restore old preferences that have not been modified in the new SDK version.
 
-Apps that have migrated to version 13.0.0 should update. Apps currently on version 12.1.0 and below should only migrate to 13.0.1 to avoid a bug in version 13.0.0.
+**Apps that have migrated to 13.0.0 from an older version should update. Apps currently on version 12.1.0 and below should only migrate to 13.0.1 to avoid a bug in version 13.0.0.**
 
 ### Changes
 - Updated iOS SDK to 16.0.2
 
 ## Version 13.0.0 - October 20, 2021
+
+**Due to a bug that mishandles persisted SDK settings, apps that are migrating from plugin 12.1.0 or older should avoid this version and instead use 13.0.1 or newer.**
+
 Major release to provide new features and include the latest iOS and Android SDKs. This version requires Xcode 13 for iOS and compileSdkVersion 31 and java 8 source compatibility for Android.
 
 - Added urbanairship-preference-center-react-native module. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # React Native Module Changelog
 
+## Version 13.0.1 - November 5, 2021
+Patch release that fixes preferences resetting when upgrading to SDK 15/16. This update will restore old preferences that have not been modified in the new SDK version.
+
+Apps that have migrated to version 13.0.0 should update. Apps currently on version 12.1.0 and below should only migrate to 13.0.1 to avoid a bug in version 13.0.0.
+
+### Changes
+- Updated iOS SDK to 16.0.2
+
 ## Version 13.0.0 - October 20, 2021
 Major release to provide new features and include the latest iOS and Android SDKs. This version requires Xcode 13 for iOS and compileSdkVersion 31 and java 8 source compatibility for Android.
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -13,7 +13,7 @@ end
 target 'ServiceExtension' do
   platform :ios, '11.0'
   # Pods for Service Extension
-  pod 'AirshipExtensions/NotificationService', '~> 16.0.1'
+  pod 'AirshipExtensions/NotificationService', '~> 16.0.2'
 end
 
 # https://github.com/software-mansion/react-native-screens/issues/842

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,26 +1,26 @@
 PODS:
-  - Airship (16.0.1):
-    - Airship/Automation (= 16.0.1)
-    - Airship/Basement (= 16.0.1)
-    - Airship/Core (= 16.0.1)
-    - Airship/ExtendedActions (= 16.0.1)
-    - Airship/MessageCenter (= 16.0.1)
-  - Airship/Accengage (16.0.1):
+  - Airship (16.0.2):
+    - Airship/Automation (= 16.0.2)
+    - Airship/Basement (= 16.0.2)
+    - Airship/Core (= 16.0.2)
+    - Airship/ExtendedActions (= 16.0.2)
+    - Airship/MessageCenter (= 16.0.2)
+  - Airship/Accengage (16.0.2):
     - Airship/Core
-  - Airship/Automation (16.0.1):
+  - Airship/Automation (16.0.2):
     - Airship/Core
-  - Airship/Basement (16.0.1)
-  - Airship/Chat (16.0.1):
+  - Airship/Basement (16.0.2)
+  - Airship/Chat (16.0.2):
     - Airship/Core
-  - Airship/Core (16.0.1):
+  - Airship/Core (16.0.2):
     - Airship/Basement
-  - Airship/ExtendedActions (16.0.1):
+  - Airship/ExtendedActions (16.0.2):
     - Airship/Core
-  - Airship/MessageCenter (16.0.1):
+  - Airship/MessageCenter (16.0.2):
     - Airship/Core
-  - Airship/PreferenceCenter (16.0.1):
+  - Airship/PreferenceCenter (16.0.2):
     - Airship/Core
-  - AirshipExtensions/NotificationService (16.0.1)
+  - AirshipExtensions/NotificationService (16.0.2)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.64.0)
@@ -299,24 +299,24 @@ PODS:
     - React-Core
   - RNScreens (2.18.1):
     - React-Core
-  - urbanairship-accengage-react-native (13.0.0):
-    - Airship/Accengage (= 16.0.1)
+  - urbanairship-accengage-react-native (13.0.1):
+    - Airship/Accengage (= 16.0.2)
     - React-Core
-  - urbanairship-chat-react-native (13.0.0):
-    - Airship/Chat (= 16.0.1)
-    - React-Core
-    - urbanairship-react-native
-  - urbanairship-preference-center-react-native (13.0.0):
-    - Airship/PreferenceCenter (= 16.0.1)
+  - urbanairship-chat-react-native (13.0.1):
+    - Airship/Chat (= 16.0.2)
     - React-Core
     - urbanairship-react-native
-  - urbanairship-react-native (13.0.0):
-    - Airship (= 16.0.1)
+  - urbanairship-preference-center-react-native (13.0.1):
+    - Airship/PreferenceCenter (= 16.0.2)
+    - React-Core
+    - urbanairship-react-native
+  - urbanairship-react-native (13.0.1):
+    - Airship (= 16.0.2)
     - React-Core
   - Yoga (1.14.0)
 
 DEPENDENCIES:
-  - AirshipExtensions/NotificationService (~> 16.0.1)
+  - AirshipExtensions/NotificationService (~> 16.0.2)
   - DoubleConversion (from `../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../../node_modules/react-native/React/FBReactNativeSpec`)
@@ -440,12 +440,12 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: 5fe7c3e50244f4588971da98f9e3b0aa865f5ec0
-  AirshipExtensions: a176a12cd5425991be578281138712d3926479c2
+  Airship: d85180651dedb39aacd97166ccf36444deefd84c
+  AirshipExtensions: d313b7f0451f7cd820fb75a2cc6be487edf5a0b3
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 2323ee42e2adfca409ee74ca1d9c914ff6f2eb2d
+  FBReactNativeSpec: 938a018ef5f57310a471c65d708d0416bf4cd1e2
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
@@ -475,12 +475,12 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 514a11da3a2bcc6c3dfd9de32b38e2b9bf101926
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
-  urbanairship-accengage-react-native: 6f2aa10ab7857774b96458c1e1d0bf0e775ad964
-  urbanairship-chat-react-native: 91fc892ce968e7b6ac3453d3a356f35d540062cd
-  urbanairship-preference-center-react-native: d24aab2c8dc1efd780b36e212513133858729add
-  urbanairship-react-native: a1b93414bae4425e96a2566aa01bf90ded298081
+  urbanairship-accengage-react-native: 619c3f4f02cbf409218d007aed2d110670fdc36c
+  urbanairship-chat-react-native: 33b115b90eb3e4993daa1989c659c28a3bf62a25
+  urbanairship-preference-center-react-native: bfd03f93a733bc4c941f05e15a497380e9093b01
+  urbanairship-react-native: 4b932a1e1d988bffb4717cb11d033f86826bb809
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: d3c7d600e40de805e96cd779f1b5034a1fd0269e
+PODFILE CHECKSUM: a81059fd8461bbbef3ea72bc1626c0026331babb
 
 COCOAPODS: 1.11.0

--- a/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
+++ b/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipAccengageReactModuleVersion.h"
 
-NSString *const moduleVersionString = @"13.0.0";
+NSString *const moduleVersionString = @"13.0.1";
 
 @implementation AirshipAccengageReactModuleVersion
 

--- a/urbanairship-accengage-react-native/package.json
+++ b/urbanairship-accengage-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-react-native",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Airship accengage module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
+++ b/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Accengage", "16.0.1"
+  s.dependency "Airship/Accengage", "16.0.2"
 
 end
 

--- a/urbanairship-chat-react-native/package.json
+++ b/urbanairship-chat-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-chat-react-native",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Airship chat module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-chat-react-native/urbanairship-chat-react-native.podspec
+++ b/urbanairship-chat-react-native/urbanairship-chat-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Chat", "16.0.1"
+  s.dependency "Airship/Chat", "16.0.2"
   s.dependency "urbanairship-react-native"
 end
 

--- a/urbanairship-hms-react-native/package.json
+++ b/urbanairship-hms-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-react-native",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Airship HMS module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-preference-center-react-native/package.json
+++ b/urbanairship-preference-center-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-preference-center-react-native",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Airship preference center module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-preference-center-react-native/urbanairship-preference-center-react-native.podspec
+++ b/urbanairship-preference-center-react-native/urbanairship-preference-center-react-native.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/PreferenceCenter", "16.0.1"
+  s.dependency "Airship/PreferenceCenter", "16.0.2"
   s.dependency "urbanairship-react-native"
 end

--- a/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const airshipModuleVersionString = @"13.0.0";
+NSString *const airshipModuleVersionString = @"13.0.1";
 
 + (nonnull NSString *)get {
     return airshipModuleVersionString;

--- a/urbanairship-react-native/package.json
+++ b/urbanairship-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Airship plugin for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-react-native/urbanairship-react-native.podspec
+++ b/urbanairship-react-native/urbanairship-react-native.podspec
@@ -13,5 +13,5 @@ require "json"
   s.source       = { :git => "https://github.com/urbanairship/react-native-module.git", :tag => "{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
   s.dependency "React-Core"
-  s.dependency "Airship", "16.0.1"
+  s.dependency "Airship", "16.0.2"
 end


### PR DESCRIPTION
### What do these changes do?

Prep release 13.0.1

- Updated iOS SDK to `16.0.2`
- Updated iOS sample pods
- Changelog entry for `13.0.1`

### How did you verify these changes?

Ran sample apps