### PR TITLE
Fix isDeleted on iOS

### DIFF
--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -503,7 +503,7 @@ RCT_REMAP_METHOD(getInboxMessages,
         [messageInfo setValue:iconUrl forKey:@"listIconUrl"];
         [messageInfo setValue:message.unread ? @NO : @YES  forKey:@"isRead"];
         [messageInfo setValue:message.extra forKey:@"extras"];
-        [messageInfo setObject:message.deleted ? @NO : @YES forKey:@"isDeleted"];
+        [messageInfo setObject:message.deleted ? @YES : @NO forKey:@"isDeleted"];
 
         [messages addObject:messageInfo];
     }


### PR DESCRIPTION
Fixes `isDeleted` on a message. A pointless flag since if they are deleted they no longer show up in the message list, but it should at least be accurate. 