### PR TITLE
Call takeOff when bridge is set

### DIFF
--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -37,6 +37,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)setBridge:(RCTBridge *)bridge {
+    [UARCTAutopilot takeOffWithLaunchOptions:bridge.launchOptions];
     [UARCTEventEmitter shared].bridge = bridge;
 }
 


### PR DESCRIPTION
Calls takeOff when the bridge is set to workaround the react view being displayed before applicationDidFinishLaunching. This should fix issue GH-371.