### PR TITLE
[MOBILE-2625-follow] Stub methods to fix react warning

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -159,6 +159,16 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
     public void setAndroidNotificationConfig(ReadableMap map) {
         Context context = getReactApplicationContext();
         ReactAirshipPreferences prefs = ReactAirshipPreferences.shared();


### PR DESCRIPTION
### What do these changes do?
Stub addListener and removeListeners methods

### Why are these changes necessary?
We need to stub the addListener and removeListeners methods in the react framework too to avoid these kind of warnings:

WARN new NativeEventEmitter() was called with a non-null argument without the required addListener method.
AirshipSample@http://10.0.2.2:8081/example/index.bundle?platform=android&dev=true&minify=false&app=com.urbanairship.sample&modulesOnly=false&runModule=true:110004:36

### How did you verify these changes?
Tested it during MOBILE-2625 on our Gimbal adapter sample which had this issue

#### Verification Screenshots:

### Anything else a reviewer should know?
