### PR TITLE
Fix notification response callback

### DIFF
--- a/urbanairship-react-native/ios/UARCTModule/UARCTUtils.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTUtils.m
@@ -136,7 +136,7 @@
     }
 
     // Fill in the notification title, subtitle and body if exists
-    NSDictionary* aps = extras[@"aps"];
+    NSDictionary* aps = userInfo[@"aps"];
     if (aps) {
         id alert = aps[@"alert"];
         if ([alert isKindOfClass:[NSDictionary class]]) {


### PR DESCRIPTION
### What do these changes do?
 Fix an issue with notification response callback not returning some information like title, subtitle and body.
We use extras dictionary instead of userInfo.

### How did you verify these changes?
I used sample app
