### PR TITLE
[GHI-433] fix null preferences

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
@@ -218,17 +218,19 @@ public class ReactAirshipPreferences {
     }
 
     private void ensurePreferences() {
-        if (preferences == null) {
-            this.preferences = context.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
-        }
+        synchronized (this) {
+            if (preferences == null) {
+                this.preferences = context.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
+            }
 
-        if (!created.getAndSet(true)) {
-            // Migrate any data stored in default
-            SharedPreferences defaultPreferences = PreferenceManager.getDefaultSharedPreferences(context);
-            if (defaultPreferences.contains(AUTO_LAUNCH_MESSAGE_CENTER)) {
-                boolean autoLaunchMessageCenter = defaultPreferences.getBoolean(AUTO_LAUNCH_MESSAGE_CENTER, true);
-                defaultPreferences.edit().remove(AUTO_LAUNCH_MESSAGE_CENTER).apply();
-                this.preferences.edit().putBoolean(AUTO_LAUNCH_MESSAGE_CENTER, autoLaunchMessageCenter).apply();
+            if (!created.getAndSet(true)) {
+                // Migrate any data stored in default
+                SharedPreferences defaultPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+                if (defaultPreferences.contains(AUTO_LAUNCH_MESSAGE_CENTER)) {
+                    boolean autoLaunchMessageCenter = defaultPreferences.getBoolean(AUTO_LAUNCH_MESSAGE_CENTER, true);
+                    defaultPreferences.edit().remove(AUTO_LAUNCH_MESSAGE_CENTER).apply();
+                    this.preferences.edit().putBoolean(AUTO_LAUNCH_MESSAGE_CENTER, autoLaunchMessageCenter).apply();
+                }
             }
         }
     }

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
@@ -40,7 +40,7 @@ public class ReactAirshipPreferences {
     private static final String AUTO_LAUNCH_MESSAGE_CENTER = "com.urbanairship.auto_launch_message_center";
     private static final String AIRSHIP_CONFIG = "airship_config";
 
-    private AtomicBoolean created = new AtomicBoolean(false);
+    private final Object lock = new Object();
     private Context context;
 
     public ReactAirshipPreferences(@NonNull Context context) {
@@ -218,12 +218,10 @@ public class ReactAirshipPreferences {
     }
 
     private void ensurePreferences() {
-        synchronized (this) {
+        synchronized (lock) {
             if (preferences == null) {
                 this.preferences = context.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
-            }
 
-            if (!created.getAndSet(true)) {
                 // Migrate any data stored in default
                 SharedPreferences defaultPreferences = PreferenceManager.getDefaultSharedPreferences(context);
                 if (defaultPreferences.contains(AUTO_LAUNCH_MESSAGE_CENTER)) {

--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactAirshipPreferences.java
@@ -218,9 +218,11 @@ public class ReactAirshipPreferences {
     }
 
     private void ensurePreferences() {
-        if (!created.getAndSet(true)) {
+        if (preferences == null) {
             this.preferences = context.getSharedPreferences(SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
+        }
 
+        if (!created.getAndSet(true)) {
             // Migrate any data stored in default
             SharedPreferences defaultPreferences = PreferenceManager.getDefaultSharedPreferences(context);
             if (defaultPreferences.contains(AUTO_LAUNCH_MESSAGE_CENTER)) {


### PR DESCRIPTION
With only the atomic boolean there are possibilities to have a null sharedPreferences.

We can keep the atomic boolean and add a null check to initialize the sharedPreferences.
Or we can remove the atomic boolean and just keep the null check.