### PR TITLE
Fix a crash when trying to load a message with a poor connection

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactMessageView.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactMessageView.java
@@ -118,7 +118,7 @@ public class ReactMessageView extends FrameLayout implements LifecycleEventListe
                         return;
                     }
 
-                    webView.loadMessage(message);
+                    displayMessage();
                 }
             });
         } else {
@@ -126,6 +126,12 @@ public class ReactMessageView extends FrameLayout implements LifecycleEventListe
                 notifyLoadError(messageId, ERROR_MESSAGE_NOT_AVAILABLE, false);
                 return;
             }
+            displayMessage();
+        }
+    }
+
+    private void displayMessage() {
+        if (webView != null) {
             webView.loadMessage(this.message);
         }
     }


### PR DESCRIPTION
### What do these changes do?
Fix a crash when trying to load a message with a poor connection
[This crash was ](https://github.com/urbanairship/react-native-module/issues/439)

### How did you verify these changes?
Sample app
How to reproduce:
- Setup a poor network condition in the emulator.
- Comment out  
https://github.com/urbanairship/react-native-module/blob/1962b36cfa543810ba878d57e12478fcda3f1821/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/ReactMessageView.java#L107
- Open a message from the message center and quit before the `onFinished` callback is called.

