### PR TITLE
[MOBILE-3287] Expose IAA display interval

### DIFF
--- a/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
+++ b/urbanairship-react-native/android/src/main/java/com/urbanairship/reactnative/UrbanAirshipReactModule.java
@@ -44,6 +44,7 @@ import com.urbanairship.actions.ActionCompletionCallback;
 import com.urbanairship.actions.ActionResult;
 import com.urbanairship.actions.ActionRunRequest;
 import com.urbanairship.analytics.AssociatedIdentifiers;
+import com.urbanairship.automation.InAppAutomation;
 import com.urbanairship.channel.AirshipChannelListener;
 import com.urbanairship.channel.AttributeEditor;
 import com.urbanairship.channel.SubscriptionListEditor;
@@ -71,6 +72,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * React module for Urban Airship.
@@ -1224,6 +1226,14 @@ public class UrbanAirshipReactModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void clearLocale() {
         UAirship.shared().setLocaleOverride(null);
+    }
+
+    /**
+     * Sets the minimum number of seconds between IAA displays.
+     */
+    @ReactMethod
+    public void setInAppAutomationDisplayInterval(double seconds) {
+        InAppAutomation.shared().getInAppMessageManager().setDisplayInterval((long) seconds, TimeUnit.SECONDS);
     }
 
     /**

--- a/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
+++ b/urbanairship-react-native/ios/UARCTModule/UrbanAirshipReactModule.m
@@ -918,6 +918,10 @@ RCT_EXPORT_METHOD(clearNotification:(NSString *)identifier) {
     }
 }
 
+RCT_EXPORT_METHOD(setInAppAutomationDisplayInterval:(NSInteger)seconds) {
+    UAInAppAutomation.shared.inAppMessageManager.displayInterval = seconds;
+}
+
 RCT_REMAP_METHOD(getUnreadMessagesCount,
                  getUnreadMessagesCount_resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {

--- a/urbanairship-react-native/js/UrbanAirship.ts
+++ b/urbanairship-react-native/js/UrbanAirship.ts
@@ -1398,4 +1398,13 @@ export class UrbanAirship {
   static clearNotification(identifier: string) {
     UrbanAirshipModule.clearNotification(identifier)
   }
+
+  /**
+   * Sets the in-app message display interval on the default display coordinator.
+   *
+   * @param seconds The minimum number of seconds between message displays.
+   */
+  static setInAppAutomationDisplayInterval(seconds: number) {
+    UrbanAirshipModule.setInAppAutomationDisplayInterval(seconds)
+  }
 }


### PR DESCRIPTION
Retargeted to a new `release-14.4.4` branch, off of `14.4.3`

### What do these changes do?

* Fixes Android chat module version
* Adds support for configuring the IAA display interval at runtime

### Why are these changes necessary?

Feature request

### How did you verify these changes?

- Confirmed the call made it to the native layers using the Android and iOS samples
- Ran tests
