### PR TITLE
Release 14.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # React Native Module Changelog
 
+## Version 14.4.4 - October 6, 2022
+Patch release that adds support for setting the IAA message display interval.
+
+###
+- Add `UrbanAirship.setInAppAutomationDisplayInterval()` method
+- Updated Airship Android SDK to 16.7.5
+- Updated Airship iOS SDK to 16.9.4
+
 ## Version 14.4.3 - September 9, 2022
 Patch release that fixes an IAA banner issue and potential crashes on Android due to Message Center database migrations.
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - Airship (16.9.3):
-    - Airship/Automation (= 16.9.3)
-    - Airship/Basement (= 16.9.3)
-    - Airship/Core (= 16.9.3)
-    - Airship/ExtendedActions (= 16.9.3)
-    - Airship/MessageCenter (= 16.9.3)
-  - Airship/Accengage (16.9.3):
+  - Airship (16.9.4):
+    - Airship/Automation (= 16.9.4)
+    - Airship/Basement (= 16.9.4)
+    - Airship/Core (= 16.9.4)
+    - Airship/ExtendedActions (= 16.9.4)
+    - Airship/MessageCenter (= 16.9.4)
+  - Airship/Accengage (16.9.4):
     - Airship/Core
-  - Airship/Automation (16.9.3):
+  - Airship/Automation (16.9.4):
     - Airship/Core
-  - Airship/Basement (16.9.3)
-  - Airship/Chat (16.9.3):
+  - Airship/Basement (16.9.4)
+  - Airship/Chat (16.9.4):
     - Airship/Core
-  - Airship/Core (16.9.3):
+  - Airship/Core (16.9.4):
     - Airship/Basement
-  - Airship/ExtendedActions (16.9.3):
+  - Airship/ExtendedActions (16.9.4):
     - Airship/Core
-  - Airship/MessageCenter (16.9.3):
+  - Airship/MessageCenter (16.9.4):
     - Airship/Core
-  - Airship/PreferenceCenter (16.9.3):
+  - Airship/PreferenceCenter (16.9.4):
     - Airship/Core
   - AirshipServiceExtension (16.6.0)
   - boost-for-react-native (1.63.0)
@@ -299,19 +299,19 @@ PODS:
     - React-Core
   - RNScreens (2.18.1):
     - React-Core
-  - urbanairship-accengage-react-native (14.4.3):
-    - Airship/Accengage (= 16.9.3)
+  - urbanairship-accengage-react-native (14.4.4):
+    - Airship/Accengage (= 16.9.4)
     - React-Core
-  - urbanairship-chat-react-native (14.4.3):
-    - Airship/Chat (= 16.9.3)
-    - React-Core
-    - urbanairship-react-native
-  - urbanairship-preference-center-react-native (14.4.3):
-    - Airship/PreferenceCenter (= 16.9.3)
+  - urbanairship-chat-react-native (14.4.4):
+    - Airship/Chat (= 16.9.4)
     - React-Core
     - urbanairship-react-native
-  - urbanairship-react-native (14.4.3):
-    - Airship (= 16.9.3)
+  - urbanairship-preference-center-react-native (14.4.4):
+    - Airship/PreferenceCenter (= 16.9.4)
+    - React-Core
+    - urbanairship-react-native
+  - urbanairship-react-native (14.4.4):
+    - Airship (= 16.9.4)
     - React-Core
   - Yoga (1.14.0)
 
@@ -440,12 +440,12 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: e695e80794ce7036d94d2bd0e837c7a24efa5c65
+  Airship: e3238648bc020081a009ea2cc7a594816a58f432
   AirshipServiceExtension: 36efe25642746cc030844116d59fb366b26da76f
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 72f307e3ea9e80cf68fb886064a447aa7a3996ff
+  FBReactNativeSpec: ee6f9a72ef7a5f7dd05c2d2bdc791799c7eb2cf7
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
@@ -475,10 +475,10 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: c1b56d030d1616239861534d9adb531f8cffab68
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
-  urbanairship-accengage-react-native: 261b92a981c579e5886ed050d8709e95b344e9af
-  urbanairship-chat-react-native: 330e7ed2b9444114208c573825968a9bd37d0952
-  urbanairship-preference-center-react-native: 6cc885225840e55d8852a633d1d21a1f7ecbfca6
-  urbanairship-react-native: a4a361ec3c66aa87e15c8fa31973a028a58ccf9d
+  urbanairship-accengage-react-native: 561f44ad42279cf273ae0f1f13f7bd1993679b58
+  urbanairship-chat-react-native: 8d11537fa7bb757df95668522195c08c32ab77c4
+  urbanairship-preference-center-react-native: 855186cb410e0546aab46f67c8bb0bc8aca760df
+  urbanairship-react-native: 960954c0c8e3f436a6cae01610389b43c63ee0e7
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
 PODFILE CHECKSUM: 0ac33f74cca01098af99ab55a29cc63c7ef373f6

--- a/urbanairship-accengage-react-native/android/build.gradle
+++ b/urbanairship-accengage-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "16.7.2"
+    airshipVersion = "16.7.5"
 }
 
 android {

--- a/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
+++ b/urbanairship-accengage-react-native/ios/AirshipAccengageReactModuleVersion.m
@@ -2,7 +2,7 @@
 
 #import "AirshipAccengageReactModuleVersion.h"
 
-NSString *const moduleVersionString = @"14.4.3";
+NSString *const moduleVersionString = @"14.4.4";
 
 @implementation AirshipAccengageReactModuleVersion
 

--- a/urbanairship-accengage-react-native/package.json
+++ b/urbanairship-accengage-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-accengage-react-native",
-  "version": "14.4.3",
+  "version": "14.4.4",
   "description": "Airship accengage module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
+++ b/urbanairship-accengage-react-native/urbanairship-accengage-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Accengage", "16.9.3"
+  s.dependency "Airship/Accengage", "16.9.4"
 
 end
 

--- a/urbanairship-chat-react-native/android/build.gradle
+++ b/urbanairship-chat-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "16.7.2"
+    airshipVersion = "16.7.5"
 }
 
 android {

--- a/urbanairship-chat-react-native/package.json
+++ b/urbanairship-chat-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-chat-react-native",
-  "version": "14.4.3",
+  "version": "14.4.4",
   "description": "Airship chat module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-chat-react-native/urbanairship-chat-react-native.podspec
+++ b/urbanairship-chat-react-native/urbanairship-chat-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/Chat", "16.9.3"
+  s.dependency "Airship/Chat", "16.9.4"
   s.dependency "urbanairship-react-native"
 end
 

--- a/urbanairship-hms-react-native/android/build.gradle
+++ b/urbanairship-hms-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "16.7.2"
+    airshipVersion = "16.7.5"
 }
 
 android {

--- a/urbanairship-hms-react-native/package.json
+++ b/urbanairship-hms-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-hms-react-native",
-  "version": "14.4.3",
+  "version": "14.4.4",
   "description": "Airship HMS module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-preference-center-react-native/android/build.gradle
+++ b/urbanairship-preference-center-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-  airshipVersion = "16.7.2"
+  airshipVersion = "16.7.5"
 }
 
 android {

--- a/urbanairship-preference-center-react-native/package.json
+++ b/urbanairship-preference-center-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-preference-center-react-native",
-  "version": "14.4.3",
+  "version": "14.4.4",
   "description": "Airship preference center module for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-preference-center-react-native/urbanairship-preference-center-react-native.podspec
+++ b/urbanairship-preference-center-react-native/urbanairship-preference-center-react-native.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Airship/PreferenceCenter", "16.9.3"
+  s.dependency "Airship/PreferenceCenter", "16.9.4"
   s.dependency "urbanairship-react-native"
 end

--- a/urbanairship-react-native/android/build.gradle
+++ b/urbanairship-react-native/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 ext {
-    airshipVersion = "16.7.2"
+    airshipVersion = "16.7.5"
 }
 
 android {

--- a/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
+++ b/urbanairship-react-native/ios/UARCTModule/UARCTModuleVersion.m
@@ -4,7 +4,7 @@
 
 @implementation UARCTModuleVersion
 
-NSString *const airshipModuleVersionString = @"14.4.3";
+NSString *const airshipModuleVersionString = @"14.4.4";
 
 + (nonnull NSString *)get {
     return airshipModuleVersionString;

--- a/urbanairship-react-native/package.json
+++ b/urbanairship-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbanairship-react-native",
-  "version": "14.4.3",
+  "version": "14.4.4",
   "description": "Airship plugin for React Native apps.",
   "author": "Airship",
   "homepage": "https://github.com/urbanairship/react-native-module",

--- a/urbanairship-react-native/urbanairship-react-native.podspec
+++ b/urbanairship-react-native/urbanairship-react-native.podspec
@@ -13,5 +13,5 @@ require "json"
   s.source       = { :git => "https://github.com/urbanairship/react-native-module.git", :tag => "{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
   s.dependency "React-Core"
-  s.dependency "Airship", "16.9.3"
+  s.dependency "Airship", "16.9.4"
 end


### PR DESCRIPTION
### What do these changes do?

Preps release 14.4.4:
- Add `UrbanAirship.setInAppAutomationDisplayInterval()` method
- Updated Airship Android SDK to 16.7.5
- Updated Airship iOS SDK to 16.9.4

### Why are these changes necessary?

:shipit: 

### How did you verify these changes?

Ran Android and iOS samples