### PR TITLE
[MOBILE-5309] Update the headless task time out and make sure it ends

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=36
 Airship_compileSdkVersion=36
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=14.9.0
+Airship_airshipProxyVersion=14.10.0

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
 
         <service
             android:name="com.urbanairship.reactnative.AirshipHeadlessEventService"
-            android:exported="false" />
+            android:exported="false"
+            android:stopWithTask="true" />
 
         <activity
             android:name="com.urbanairship.android.framework.proxy.CustomMessageCenterActivity"

--- a/android/src/main/java/com/urbanairship/reactnative/AirshipHeadlessEventService.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipHeadlessEventService.kt
@@ -26,7 +26,7 @@ class AirshipHeadlessEventService : HeadlessJsTaskService() {
     }
 
     companion object {
-        private const val TASK_TIMEOUT: Long = 60000
+        private const val TASK_TIMEOUT: Long = 1000
         private const val TASK_KEY = "AirshipAndroidBackgroundEventTask"
 
         fun startService(context: Context): Boolean {

--- a/example/index.js
+++ b/example/index.js
@@ -1,5 +1,34 @@
 import { AppRegistry } from 'react-native';
 import App from './src/App';
 import { name as appName } from './app.json';
+import Airship, { EventType } from '@ua/react-native-airship';
+
+Airship.addListener(EventType.PushReceived, (event) => {
+    // Handle push received
+    console.log("PushReceived");
+    Airship.channel.editAttributes()
+    .setAttribute("ulrich_first_param", "Ulrich RN 25")
+    .apply();
+    Airship.channel.editTags()
+    .addTags(["Ulrich RN Receive 25"])
+    .apply()
+});
+
+// Set up event listeners
+Airship.addListener(EventType.NotificationResponse, (event) => {
+    // Handle notification responses
+});
+
+Airship.addListener(EventType.PushReceived, (event) => {
+    // Handle push received
+});
+
+Airship.addListener(EventType.ChannelCreated, (event) => {
+    // Handle channel creation
+});
+
+Airship.addListener(EventType.PushNotificationStatusChangedStatus, (event) => {
+    // Handle push notification status changes
+});
 
 AppRegistry.registerComponent(appName, () => App);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,23 +32,6 @@ export default function App() {
           }
         });
 
-        // Set up event listeners
-        Airship.addListener(EventType.NotificationResponse, (event) => {
-          // Handle notification responses
-        });
-
-        Airship.addListener(EventType.PushReceived, (event) => {
-          // Handle push received
-        });
-
-        Airship.addListener(EventType.ChannelCreated, (event) => {
-          // Handle channel creation
-        });
-
-        Airship.addListener(EventType.PushNotificationStatusChangedStatus, (event) => {
-          // Handle push notification status changes
-        });
-
         setIsAirshipReady(true);
       } catch (error) {
         setAirshipError(error instanceof Error ? error.message : String(error));

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
   
-  s.dependency "AirshipFrameworkProxy", "14.9.0"
+  s.dependency "AirshipFrameworkProxy", "14.10.0"
 end


### PR DESCRIPTION
- Updated the headless task time out and make sure the service stops when the task is over.
- Moved the listeners from App to index.js to provide a better example
- Updated the proxy version with SDK 19.x

The global state issue is now fixed with the new time out.
The headless task is triggered correctly with a high priority push as it wakes up the app. It doesn't work with normal priority because service can't be launched from background anymore.
The listeners needs to be set from the index.js to work on app killed state though. Otherwise it won't be handled as it won't have the same context as the headless task.