### PR TITLE
Release 26.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # React Native Module 26.0.0 Changelog
 
+## Version 26.0.1 - December 19, 2025
+
+Patch release that updates the Android SDK to  and the iOS SDK to .
+
+### Changes
+- Updated Android SDK to [](https://github.com/urbanairship/android-library/releases/tag/)
+- Updated iOS SDK to [](https://github.com/urbanairship/ios-library/releases/tag/)
+
+
 [Migration Guide](https://github.com/urbanairship/react-native-airship/blob/main/MIGRATION.md)
 
 ## Version 26.0.0 - December 8, 2025

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=36
 Airship_compileSdkVersion=36
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=15.0.1
+Airship_airshipProxyVersion=15.0.3

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -39,7 +39,7 @@ public class AirshipReactNative: NSObject {
         AirshipProxy.shared
     }
 
-    public static let version: String = "26.0.0"
+    public static let version: String = "26.0.1"
 
     private let eventNotifier = EventNotifier()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/react-native-airship",
-      "version": "26.0.0",
+      "version": "26.0.1",
       "license": "Apache-2.0",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "description": "Airship plugin for React Native apps.",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
   
-  s.dependency "AirshipFrameworkProxy", "15.0.1"
+  s.dependency "AirshipFrameworkProxy", "15.0.3"
 end


### PR DESCRIPTION
Automated release preparation for React Native v26.0.1

## Version Updates
- Plugin: 26.0.1
- Framework Proxy: 15.0.3
- iOS SDK: not specified
- Android SDK: not specified

## Validation Reminder
⚠️ **Note:** Since this release updates the underlying native SDKs, the changelog entries across all framework plugins will be similar. This is expected and correct.

## Changed Files
```
CHANGELOG.md
android/gradle.properties
ios/AirshipReactNative.swift
package-lock.json
package.json
react-native-airship.podspec
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready

---
🤖 Generated by centralized release automation