### PR TITLE
Upload docs to GitHub Pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,11 @@ jobs:
       - run: npm run docs
       - run: bash ./scripts/upload_docs.sh ${GITHUB_REF/refs\/tags\//}
 
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
   github-release:
     needs: check-version
     runs-on: ubuntu-latest
@@ -88,3 +93,18 @@ jobs:
           body: ${{ steps.get_release_notes.outputs.NOTES }}
           draft: false
           prerelease: false
+
+  deploy-docs:
+    needs: docs
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Remove when migration to GH Pages is complete
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,11 @@ android/generated
 
 # React Native Nitro Modules
 nitrogen/
+
+# Generated docs
+docs/
+
+# Secrets
+airshipconfig.properties
+AirshipConfig.plist
+google-services.json

--- a/src/AirshipLiveActivityManager.ts
+++ b/src/AirshipLiveActivityManager.ts
@@ -23,7 +23,6 @@ export class AirshipLiveActivityManager {
 
   /**
    * Lists all Live Activities.
-   * @param request The request options.
    * @returns A promise with the result.
    */
   public listAll(): Promise<LiveActivity[]> {

--- a/src/AttributeEditor.ts
+++ b/src/AttributeEditor.ts
@@ -100,10 +100,9 @@ export class AttributeEditor {
    * Adds a JSON attribute.
    * 
    * @param name The attribute name.
-   * @param value The attribute value.
    * @param instanceId The instance ID.
    * @param json The json value. Must not contain `exp` as top level key.
-   * @param expiration: Optional expiration.  
+   * @param expiration Optional expiration.
    * @return The attribute editor instance.
    */
    setJsonAttribute(

--- a/src/MessageView.tsx
+++ b/src/MessageView.tsx
@@ -81,25 +81,25 @@ export interface MessageViewProps {
   /**
    * A callback when the view starts loading a message.
    *
-   * @param event: The message load started event.
+   * @param event The message load started event.
    */
   onLoadStarted?: (event: MessageLoadStartedEvent) => void;
   /**
    * A callback when the view finishes loading a message.
    *
-   * @param event: The message load finished event.
+   * @param event The message load finished event.
    */
   onLoadFinished?: (event: MessageLoadFinishedEvent) => void;
   /**
    * A callback when the view fails to load a message with an error.
    *
-   * @param event: The message load error event.
+   * @param event The message load error event.
    */
   onLoadError?: (event: MessageLoadErrorEvent) => void;
   /**
    * A callback when the message is closed.
    *
-   * @param event: The message closed event.
+   * @param event The message closed event.
    */
   onClose?: (event: MessageClosedEvent) => void;
 

--- a/src/TagGroupEditor.ts
+++ b/src/TagGroupEditor.ts
@@ -41,8 +41,7 @@ export class TagGroupEditor {
 
   /**
    * Adds tags to a tag group.
-   *
-   * @param tagGroup The tag group.
+   * @param group The tag group.
    * @param tags Tags to add.
    * @return The tag group editor instance.
    */
@@ -55,7 +54,7 @@ export class TagGroupEditor {
   /**
    * Removes tags from the tag group.
    *
-   * @param tagGroup The tag group.
+   * @param group The tag group.
    * @param tags Tags to remove.
    * @return The tag group editor instance.
    */
@@ -68,7 +67,7 @@ export class TagGroupEditor {
   /**
    * Overwrite the current set of tags on the Tag Group.
    *
-   * @param tagGroup The tag group.
+   * @param group The tag group.
    * @param tags Tags to set.
    * @return The tag group editor instance.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -742,7 +742,6 @@ export interface ItemBase {
 /**
  * A channel subscription item.
  * @typedef {object} ChannelSubscriptionItem
- * @memberof PreferenceCenter
  * @property {"channel_subscription"} type
  * @property {string} id the item identifier
  * @property {?CommonDisplay} display display information
@@ -808,7 +807,6 @@ export interface SectionBase {
 
 /**
  * @typedef {object} CommonSection
- * @memberof PreferenceCenter
  * @property {"section"} type
  * @property {string} id the section identifier
  * @property {?CommonDisplay} display display information

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "externalSymbolLinkMappings": {
+    "@types/react": {
+      "React.Component.render": "https://react.dev/reference/react/Component#render",
+      "React.Component.setState": "https://react.dev/reference/react/Component#setstate",
+      "React.NewLifecycle.getSnapshotBeforeUpdate": "https://react.dev/reference/react/Component#getsnapshotbeforeupdate",
+      "React.StaticLifecycle.getDerivedStateFromProps": "https://react.dev/reference/react/Component#static-getderivedstatefromprops",
+      "React.ComponentLifecycle.componentDidMount": "https://react.dev/reference/react/Component#componentdidmount"
+    }
+  }
+}


### PR DESCRIPTION
### What do these changes do?

Updates the release workflow with a new step in the `docs` job that uploads an artifact for pages and adds a new step, `deploy-docs` that deploys the uploaded artifact to GitHub Pages.

Also fixed some docs warnings that popped up when building docs locally.

### Why are these changes necessary?

API docs migration

### How did you verify these changes?

We're getting all the repos ready before enabling pages, so we'll have to wait and see. In the meantime, we have `continue-on-error: true`, so failures shouldn't impact anything.
