### PR TITLE
Add iOS localization support to sample app (en + es)

### DIFF
--- a/example/ios/AirshipExample.xcodeproj/project.pbxproj
+++ b/example/ios/AirshipExample.xcodeproj/project.pbxproj
@@ -85,15 +85,15 @@
 		7922FAAC4F9BA9CD0AA20548 /* Pods-AirshipExampleNotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirshipExampleNotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-AirshipExampleNotificationServiceExtension/Pods-AirshipExampleNotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = AirshipExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		90756ACFCBE96D65D29D4888 /* Pods-AirshipExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirshipExample.release.xcconfig"; path = "Target Support Files/Pods-AirshipExample/Pods-AirshipExample.release.xcconfig"; sourceTree = "<group>"; };
+		AA000001000000000000001 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = AirshipExample/en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA000002000000000000001 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = AirshipExample/es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA000005000000000000001 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA000006000000000000001 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C7BCD42851667694BA3CC24F /* Pods-AirshipExampleNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirshipExampleNotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-AirshipExampleNotificationServiceExtension/Pods-AirshipExampleNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		D148027A562F250A96779B7A /* Pods-AirshipExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirshipExample.debug.xcconfig"; path = "Target Support Files/Pods-AirshipExample/Pods-AirshipExample.debug.xcconfig"; sourceTree = "<group>"; };
 		DCC87EB02FD8477295970574 /* libPods-AirshipExampleNotificationServiceExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AirshipExampleNotificationServiceExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		FC6A83ED7671930C7AD05AAC /* libPods-AirshipExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AirshipExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA000001000000000000001 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		AA000002000000000000001 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		AA000005000000000000001 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		AA000006000000000000001 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -482,27 +482,6 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXVariantGroup section */
-		AA000003000000000000001 /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				AA000001000000000000001 /* en */,
-				AA000002000000000000001 /* es */,
-			);
-			name = "Localizable.strings";
-			sourceTree = "<group>";
-		};
-		AA000007000000000000001 /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				AA000005000000000000001 /* en */,
-				AA000006000000000000001 /* es */,
-			);
-			name = "Localizable.strings";
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
 /* Begin PBXTargetDependency section */
 		6308BFD82D7FF2A700296239 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -515,6 +494,27 @@
 			targetProxy = 6308C10A2D80A38400296239 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		AA000003000000000000001 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AA000001000000000000001 /* en */,
+				AA000002000000000000001 /* es */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		AA000007000000000000001 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AA000005000000000000001 /* en */,
+				AA000006000000000000001 /* es */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {

--- a/example/ios/AirshipExample.xcodeproj/project.pbxproj
+++ b/example/ios/AirshipExample.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		771CC994661F0393421A1C6F /* libPods-AirshipExampleNotificationServiceExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DCC87EB02FD8477295970574 /* libPods-AirshipExampleNotificationServiceExtension.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		A4685ED317A73D5118DD4DCF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
+		AA000004000000000000001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AA000003000000000000001 /* Localizable.strings */; };
+		AA000008000000000000001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AA000007000000000000001 /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +90,10 @@
 		DCC87EB02FD8477295970574 /* libPods-AirshipExampleNotificationServiceExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AirshipExampleNotificationServiceExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		FC6A83ED7671930C7AD05AAC /* libPods-AirshipExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AirshipExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA000001000000000000001 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA000002000000000000001 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA000005000000000000001 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA000006000000000000001 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +134,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
+				AA000003000000000000001 /* Localizable.strings */,
 			);
 			name = AirshipExample;
 			sourceTree = "<group>";
@@ -152,6 +159,7 @@
 				6308C17A2D80AA8500296239 /* ExampleWidgetsBundle.swift */,
 				6308C17B2D80AA8500296239 /* ExampleWidgetsLiveActivity.swift */,
 				6308C17C2D80AA8500296239 /* Info.plist */,
+				AA000007000000000000001 /* Localizable.strings */,
 			);
 			path = ExampleWidgets;
 			sourceTree = "<group>";
@@ -300,6 +308,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				es,
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
@@ -323,6 +332,7 @@
 				63D503112D8A7630003302CB /* Images.xcassets in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				A4685ED317A73D5118DD4DCF /* PrivacyInfo.xcprivacy in Resources */,
+				AA000004000000000000001 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -338,6 +348,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6308C17E2D80AA8500296239 /* Assets.xcassets in Resources */,
+				AA000008000000000000001 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -470,6 +481,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		AA000003000000000000001 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AA000001000000000000001 /* en */,
+				AA000002000000000000001 /* es */,
+			);
+			name = "Localizable.strings";
+			sourceTree = "<group>";
+		};
+		AA000007000000000000001 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AA000005000000000000001 /* en */,
+				AA000006000000000000001 /* es */,
+			);
+			name = "Localizable.strings";
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin PBXTargetDependency section */
 		6308BFD82D7FF2A700296239 /* PBXTargetDependency */ = {

--- a/example/ios/AirshipExample/en.lproj/Localizable.strings
+++ b/example/ios/AirshipExample/en.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+/* Live Activity */
+"live_activity.title" = "Live Update";
+"live_activity.status" = "Status: %@";

--- a/example/ios/AirshipExample/es.lproj/Localizable.strings
+++ b/example/ios/AirshipExample/es.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+/* Live Activity */
+"live_activity.title" = "Actualización en vivo";
+"live_activity.status" = "Estado: %@";

--- a/example/ios/ExampleWidgets/ExampleWidgetsLiveActivity.swift
+++ b/example/ios/ExampleWidgets/ExampleWidgetsLiveActivity.swift
@@ -11,31 +11,32 @@ import SwiftUI
 struct ExampleWidgetsLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: ExampleWidgetsAttributes.self) { context in
-            // Lock screen/banner UI goes here
+            // Lock screen/banner UI goes here.
+            // Strings are resolved using the app's supported localizations declared
+            // in Xcode (Project > Info > Localizations). The device language is only
+            // used if it matches one of those declared locales; otherwise iOS falls
+            // back to the development region (en). This is standard iOS behavior and
+            // is not specific to the Airship SDK.
             VStack {
-                Text("Hello \(context.state.emoji)")
+                Text(String(localized: "live_activity.title"))
+                    .font(.headline)
+                Text(String(format: String(localized: "live_activity.status"), context.state.emoji))
             }
             .activityBackgroundTint(Color.cyan)
             .activitySystemActionForegroundColor(Color.black)
 
         } dynamicIsland: { context in
             DynamicIsland {
-                // Expanded UI goes here.  Compose the expanded UI through
-                // various regions, like leading/trailing/center/bottom
                 DynamicIslandExpandedRegion(.leading) {
-                    Text("Leading")
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    Text("Trailing")
+                    Text(String(localized: "live_activity.title"))
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    Text("Bottom \(context.state.emoji)")
-                    // more content
+                    Text(String(format: String(localized: "live_activity.status"), context.state.emoji))
                 }
             } compactLeading: {
-                Text("L")
+                Text(String(localized: "live_activity.title"))
             } compactTrailing: {
-                Text("T \(context.state.emoji)")
+                Text(context.state.emoji)
             } minimal: {
                 Text(context.state.emoji)
             }

--- a/example/ios/ExampleWidgets/en.lproj/Localizable.strings
+++ b/example/ios/ExampleWidgets/en.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+/* Live Activity */
+"live_activity.title" = "Live Update";
+"live_activity.status" = "Status: %@";

--- a/example/ios/ExampleWidgets/es.lproj/Localizable.strings
+++ b/example/ios/ExampleWidgets/es.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+/* Live Activity */
+"live_activity.title" = "Actualización en vivo";
+"live_activity.status" = "Estado: %@";


### PR DESCRIPTION
## Summary

- Adds `es` as a declared localization in `AirshipExample.xcodeproj` alongside the existing `en`
- Adds `Localizable.strings` for both locales to the main app target and `ExampleWidgetsExtension`
- Updates `ExampleWidgetsLiveActivity` to use `String(localized:)` with a comment explaining the iOS fallback behavior

The sample app just didn't have `es` declared as a supported localization in Xcode. iOS only uses the device language if it matches one of the locales declared under Project > Info > Localizations - if it doesn't match, it falls back to the development region. Adding this to the sample so we have something concrete to point customers at when this comes up.

## Testing

Build and run on a simulator set to `es` and confirm the channel language attribute resolves to `es`. Trigger a Live Activity and verify the Spanish strings show on the lock screen and Dynamic Island. Flip back to `en` and confirm English strings still work.