### PR TITLE
Fix UIViewControllerHierarchyInconsistency crash in AirshipEmbeddedViewWrapper

### DIFF
--- a/ios/AirshipEmbeddedViewWrapper.swift
+++ b/ios/AirshipEmbeddedViewWrapper.swift
@@ -39,10 +39,20 @@ public final class AirshipEmbeddedViewWrapper: UIView {
 
     public override func didMoveToWindow() {
         super.didMoveToWindow()
-        guard !self.isAdded else { return }
-        self.viewController.willMove(toParent: self.parentViewController())
-        self.parentViewController().addChild(self.viewController)
-        self.viewController.didMove(toParent: self.parentViewController())
+
+        if self.window == nil {
+            if self.isAdded {
+                self.viewController.willMove(toParent: nil)
+                self.viewController.removeFromParent()
+                self.isAdded = false
+            }
+            return
+        }
+
+        guard !self.isAdded, let parentVC = self.parentViewController() else { return }
+        self.viewController.willMove(toParent: parentVC)
+        parentVC.addChild(self.viewController)
+        self.viewController.didMove(toParent: parentVC)
         self.viewController.view.isUserInteractionEnabled = true
         isAdded = true
     }
@@ -53,18 +63,16 @@ public final class AirshipEmbeddedViewWrapper: UIView {
     }
 }
 
-extension UIView
-{
-    //Get Parent View Controller from any view
-    func parentViewController() -> UIViewController {
+extension UIView {
+    func parentViewController() -> UIViewController? {
         var responder: UIResponder? = self
-        while !(responder is UIViewController) {
-            responder = responder?.next
-            if nil == responder {
-                break
+        while let r = responder {
+            if let vc = r as? UIViewController {
+                return vc
             }
+            responder = r.next
         }
-        return (responder as? UIViewController)!
+        return nil
     }
 }
 


### PR DESCRIPTION
### What do these changes do?

When AirshipEmbeddedViewWrapper is removed from the window, properly removes the hosted UIHostingController as a child VC before detaching. Also changes parentViewController() to return an optional instead of force-unwrapping.

### Why are these changes necessary?

UIHostingController was added as a child VC but never removed on window detach. On the next navigation that re-added it, UIKit threw UIViewControllerHierarchyInconsistency.

### How did you verify these changes?

10+ stack push/pop cycles on a screen with an embedded view - no crash with the fix in place.

#### Verification Screenshots:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-04-09 at 12 27 31" src="https://github.com/user-attachments/assets/36bb3189-d5fd-4d79-aba4-1492e93b23d0" />

### Anything else a reviewer should know?

Tab switching doesn't trigger didMoveToWindow(nil) - only stack push/pop does. Test with a stack navigator, not tabs.