### PR TITLE
Refactor docs publishing into reusable shared workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,74 @@
+name: Publish Docs
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      GCP_SA_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to publish docs for (e.g. 12.0.0)'
+        required: true
+        type: string
+
+jobs:
+  release-docs:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: development
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup GCP Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build & Package docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          npm ci
+          npm run docs
+          cd docs && tar -czf Documentation.tar.gz * && cd -
+
+      - name: Upload docs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          gsutil cp docs/Documentation.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/react-native/$VERSION.tar.gz
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy-docs:
+    needs: release-docs
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Remove when migration to GH Pages is complete
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,36 +32,6 @@ jobs:
 
       - run: npm ci
       - run: npm publish --access public
-          
-  docs:
-    needs: check-version
-    runs-on: macos-latest
-    env:
-      NODE_ENV: development
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          always-auth: true
-          registry-url: 'https://registry.npmjs.org'
-
-      - uses: google-github-actions/setup-gcloud@v0
-        with:
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-            
-      - run: npm ci
-      - run: npm run docs
-      - run: bash ./scripts/upload_docs.sh ${GITHUB_REF/refs\/tags\//}
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs
 
   github-release:
     needs: check-version
@@ -82,7 +52,7 @@ jobs:
           NOTES="${NOTES//$'\n'/'%0A'}"
           NOTES="${NOTES//$'\r'/'%0D'}"
           echo ::set-output name=NOTES::"$NOTES"
-     
+
       - name: Github Release
         uses: actions/create-release@v1.0.1
         env:
@@ -94,17 +64,24 @@ jobs:
           draft: false
           prerelease: false
 
-  deploy-docs:
-    needs: docs
-    runs-on: ubuntu-latest
-    continue-on-error: true  # Remove when migration to GH Pages is complete
+  publish-docs:
+    needs: check-version
     permissions:
+      contents: read
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit
+
+  notify-release:
+    if: always()
+    needs: [check-version, module, github-release, publish-docs]
+    runs-on: ubuntu-latest
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - uses: homoluctus/slatify@master
+        with:
+          type: ${{ (contains(needs.*.result, 'failure') && 'failure') || (contains(needs.*.result, 'cancelled') && 'cancelled') || 'success' }}
+          job_name: "React Native Release"
+          url: ${{ secrets.MOBILE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary

- Extracts the `docs` and `deploy-docs` jobs from the release workflow into a new reusable workflow at `.github/workflows/publish-docs.yml`
- The shared workflow supports `workflow_call` (triggered automatically on tag push) and `workflow_dispatch` (manual republish for any existing tag), both checking out `ref: inputs.version`
- Updates `release.yml` to call the shared workflow via a single `publish-docs` job with `secrets: inherit`
- Upgrades GCP auth from deprecated `setup-gcloud@v0` to `google-github-actions/auth@v2` + `setup-gcloud@v2`
- Adds a `notify-release` job at the end of the release workflow for Slack notifications on success/failure/cancellation

## Test plan

- [ ] Verify `workflow_dispatch` trigger appears for `publish-docs.yml` in the GitHub Actions UI with a `version` input field
- [ ] Trigger a manual run against an existing tag and confirm docs build, GCS upload, and GitHub Pages deploy succeed
- [ ] Confirm the next tag-push release runs `publish-docs` and `notify-release` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)