### PR TITLE
Update README with SDK Support Policy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,56 +108,15 @@ export default function App() {
 
 For a more detailed setup guide, please see the full [Getting Started Documentation](https://docs.airship.com/developer/sdk-integration/react-native/installation/getting-started).
 
-## Supported Versions
+## Versions and Support
 
-| Airship RN Version | Airship SDK Version | Supported RN Versions | Support Status                        |
-| :----------------- | :------------------ | :-------------------- | :------------------------------------ |
-| **26.x**           | 20.x                | 0.82.x – 0.84.x       | **Active**                            |
-| **25.x**           | 19.x                | 0.81.x – 0.82.x       | **Maintenance** (Until Jun 8, 2026)   |
-| **24.x**           | 19.x                | 0.79.x – 0.80.x       | **Unsupported**                       |
-| **23.x**           | 19.x                | 0.78.x                | **Unsupported**                       |
-| **21.x**           | 19.x                | 0.70.x – 0.77.x       | **Unsupported**                       |
-
-*Table last updated: March 16, 2026*
-
-### Support Policy Definitions
-
-Airship adheres to **Semantic Versioning** and the [React Native Support Policy](https://github.com/reactwg/react-native-releases/blob/main/docs/support.md).
-
-- **Version Strategy:** Breaking changes in React Native, Airship’s native SDKs, or the module’s public API may require a new major version.
-- **Compatibility:** Only **Active** versions are evaluated for compatibility when new React Native versions are released. Compatibility with new React Native releases may require a new major Airship version.
-- **Backports:** React Native compatibility updates are **not backported** to older Airship versions.
-
-#### Active
-
-Active versions are major releases of the Airship React Native Module that are currently in active development. These versions receive new features, bug fixes, and support for the React Native versions listed in the table above.
-
-More than one major version may be Active at the same time when each targets a different React Native version range.
-
-A new major version of the Airship React Native Module will be released if:
-1. **React Native Upgrades:** A new React Native release requires breaking changes to the module.
-2. **Airship SDK Upgrades:** The underlying native Airship SDKs (iOS/Android) introduce breaking changes or major architecture updates.
-3. **Module API Changes:** Breaking changes are made to the Airship React Native Module’s public API or packaging.
-
-#### Maintenance (End of Cycle)
-
-A major version enters a **6-month Maintenance window** when either:
-1. It is superseded by a newer major release **targeting the same React Native versions**, or
-2. The React Native versions it supports reach `End of Cycle` or `Unsupported` in the official React Native policy.
-
-- **Duration:** The maintenance window lasts for 6 months from the date the trigger occurs.
-- **Includes:** Updates include critical bug fixes and security patches, **provided they can be resolved without breaking changes**.
-- **Excludes:** Updates exclude new features or support for *future* React Native versions (e.g., RN 0.83+ will not be added to Airship 25.x).
-- **Goal:** The goal is to provide a stable transition period for customers to migrate to an Active version.
-
-#### Unsupported (End of Life)
-
-Unsupported versions are releases that have passed their Maintenance window. No updates or support are provided for these versions.
+For the current Support Status of each module major, EOL dates, and the full lifecycle policy, see the [Airship SDK Support Policy](https://www.airship.com/docs/reference/sdk-support-policy/).
 
 ## Resources
 
 - **[Documentation](https://docs.airship.com/developer/sdk-integration/react-native)** - Complete SDK integration guides and feature documentation
 - **[API Reference](https://docs.airship.com/reference/libraries/react-native/latest/)** - Detailed TypeScript API documentation
+- **[SDK Support Policy](https://www.airship.com/docs/reference/sdk-support-policy/)** - Version lifecycle, support windows, and EOL dates across all Airship SDKs
 - **[GitHub Issues](https://github.com/urbanairship/react-native-airship/issues)** - Report bugs and request features
 - **[Changelog](CHANGELOG.md)** - Release notes and version history
 - **[Migration Guide](MIGRATION.md)** - Upgrade guides between major versions


### PR DESCRIPTION
## Summary
- Replace the embedded Supported Versions table and Support Policy Definitions with a pointer to the centralized [Airship SDK Support Policy](https://www.airship.com/docs/reference/sdk-support-policy/) on docs.airship.com
- Add the SDK Support Policy link to the Resources section
- Mirrors the README update made in `capacitor-airship`

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm SDK Support Policy link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)