### PR TITLE
Release 26.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # React Native Module 26.0.0 Changelog
 
+## Version 26.6.0 - June 12, 2026
+
+Minor release that updates the Android SDK to 20.7.4 and the iOS SDK to 20.7.2.
+
+### Changes
+- Updated Android SDK to [20.7.4](https://github.com/urbanairship/android-library/releases/tag/20.7.4)
+- Updated iOS SDK to [20.7.2](https://github.com/urbanairship/ios-library/releases/tag/20.7.2)
+
+
 ## Version 26.5.0 - May 1, 2026
 
 Minor release that updates the Android SDK to 20.7.0 and the iOS SDK to 20.7.0.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=36
 Airship_compileSdkVersion=36
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=15.9.0
+Airship_airshipProxyVersion=15.9.1

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -36,7 +36,7 @@ public final class AirshipReactNative: NSObject, Sendable {
         AirshipProxy.shared
     }
 
-    public static let version: String = "26.5.0"
+    public static let version: String = "26.6.0"
 
     private let eventNotifier = EventNotifier()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "26.5.0",
+  "version": "26.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/react-native-airship",
-      "version": "26.5.0",
+      "version": "26.6.0",
       "license": "Apache-2.0",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "26.5.0",
+  "version": "26.6.0",
   "description": "Airship plugin for React Native apps.",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
   
-  s.dependency "AirshipFrameworkProxy", "15.9.0"
+  s.dependency "AirshipFrameworkProxy", "15.9.1"
 end


### PR DESCRIPTION
Automated release preparation for React Native v26.6.0

## Version Updates
- Plugin: 26.6.0
- Framework Proxy: 15.9.1
- iOS SDK: 20.7.2
- Android SDK: 20.7.4

## Validation Reminder
⚠️ **Note:** Since this release updates the underlying native SDKs, the changelog entries across all framework plugins will be similar. This is expected and correct.

## Changed Files
```
CHANGELOG.md
android/gradle.properties
ios/AirshipReactNative.swift
package-lock.json
package.json
react-native-airship.podspec
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready

---
🤖 Generated by centralized release automation