### PR TITLE
Rm gcp docs publish

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,9 +6,6 @@ on:
       version:
         required: true
         type: string
-    secrets:
-      GCP_SA_KEY:
-        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -31,27 +28,12 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Setup GCP Auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Build & Package docs
         env:
           VERSION: ${{ inputs.version }}
         run: |
           npm ci
           npm run docs
-          cd docs && tar -czf Documentation.tar.gz * && cd -
-
-      - name: Upload docs
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          gsutil cp docs/Documentation.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/react-native/$VERSION.tar.gz
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -43,7 +43,6 @@ jobs:
   deploy-docs:
     needs: release-docs
     runs-on: ubuntu-latest
-    continue-on-error: true  # Remove when migration to GH Pages is complete
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
### What do these changes do?
 
Removes GCP doc upload, since we'll be switching to GH Pages.

### Why are these changes necessary?

Docs -> GH Pages

### How did you verify these changes?

We'll do it live!

### Anything else a reviewer should know?

Don't merge this until we're actually cutting over to GH Pages. We need to keep publishing the GCP bucket until then.
