### PR TITLE
Add selection parameter to AirshipEmbeddedView

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=36
 Airship_compileSdkVersion=36
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=15.10.0
+Airship_airshipProxyVersion=15.11.0

--- a/android/src/main/java/com/urbanairship/reactnative/ReactEmbeddedView.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactEmbeddedView.kt
@@ -4,20 +4,48 @@ package com.urbanairship.reactnative
 
 import android.content.Context
 import android.widget.FrameLayout
+import com.urbanairship.embedded.AirshipEmbeddedSelection
 import com.urbanairship.embedded.AirshipEmbeddedView
 
 class ReactEmbeddedView(context: Context) : FrameLayout(context) {
 
     private var embeddedId: String? = null
+    private var selectionType: String? = null
+    private var selectionInstanceId: String? = null
+    private var rendered: Triple<String?, String?, String?>? = null
 
     fun load(embeddedId: String) {
-        if (this.embeddedId == embeddedId) {
+        this.embeddedId = embeddedId
+        rebuild()
+    }
+
+    fun setSelectionType(selectionType: String?) {
+        this.selectionType = selectionType
+        rebuild()
+    }
+
+    fun setSelectionInstanceId(selectionInstanceId: String?) {
+        this.selectionInstanceId = selectionInstanceId
+        rebuild()
+    }
+
+    private fun rebuild() {
+        val embeddedId = this.embeddedId ?: return
+        val current = Triple(embeddedId, selectionType, selectionInstanceId)
+        if (current == rendered) {
             return
+        }
+        rendered = current
+
+        val selectionInstanceId = this.selectionInstanceId
+        val selection = if (selectionType == "instance_id" && selectionInstanceId != null) {
+            AirshipEmbeddedSelection.ByInstanceId(selectionInstanceId)
+        } else {
+            AirshipEmbeddedSelection.Priority
         }
 
         removeAllViews()
-        this.embeddedId = embeddedId
-        addView(AirshipEmbeddedView(context, embeddedId))
+        addView(AirshipEmbeddedView(context, embeddedId, selection = selection))
     }
 
     override fun requestLayout() {

--- a/android/src/main/java/com/urbanairship/reactnative/ReactEmbeddedViewManager.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactEmbeddedViewManager.kt
@@ -17,6 +17,8 @@ class ReactEmbeddedViewManager : SimpleViewManager<ReactEmbeddedView>(),
         override fun setProperty(view: ReactEmbeddedView, propName: String, value: Any?) {
             when (propName) {
                 "embeddedId" -> setEmbeddedId(view, value as? String)
+                "selectionType" -> setSelectionType(view, value as? String)
+                "selectionInstanceId" -> setSelectionInstanceId(view, value as? String)
                 else -> {}
             }
         }
@@ -47,6 +49,16 @@ class ReactEmbeddedViewManager : SimpleViewManager<ReactEmbeddedView>(),
         embeddedId?.let {
             view.load(it)
         }
+    }
+
+    @ReactProp(name = "selectionType")
+    override fun setSelectionType(view: ReactEmbeddedView, selectionType: String?) {
+        view.setSelectionType(selectionType)
+    }
+
+    @ReactProp(name = "selectionInstanceId")
+    override fun setSelectionInstanceId(view: ReactEmbeddedView, selectionInstanceId: String?) {
+        view.setSelectionInstanceId(selectionInstanceId)
     }
 
     companion object {

--- a/example/src/screens/EmbeddedViewsScreen.tsx
+++ b/example/src/screens/EmbeddedViewsScreen.tsx
@@ -250,6 +250,30 @@ export default function EmbeddedViewsScreen(_props: EmbeddedViewsScreenProps) {
 
       {SIZE_CONFIGS.map(renderSizeCard)}
 
+      <View style={styles.evCard}>
+        <View style={styles.evCardHeader}>
+          <Text style={styles.evCardTitle}>Instance Selection</Text>
+        </View>
+        <Text style={styles.evCardDescription}>
+          <Text style={styles.evCodeText}>
+            selection={'{'}{'{'} type: 'instance_id', instanceId: 'demo-instance' {'}'}{'}'}
+          </Text>
+        </Text>
+        <View style={styles.evEmbeddedWrapper}>
+          {isEmbeddedReady ? (
+            <AirshipEmbeddedView
+              embeddedId={EMBEDDED_ID}
+              style={styles.evFixedHeight}
+              selection={{ type: 'instance_id', instanceId: 'demo-instance' }}
+            />
+          ) : (
+            <View style={[styles.evPlaceholder, styles.evFixedHeight]}>
+              <Text style={styles.evPlaceholderText}>{placeholderText}</Text>
+            </View>
+          )}
+        </View>
+      </View>
+
       <View style={styles.evFooter}>
         <Text style={styles.evFooterText}>
           Create one embedded content in Airship dashboard with ID: "{EMBEDDED_ID}"

--- a/ios/AirshipEmbeddedViewWrapper.swift
+++ b/ios/AirshipEmbeddedViewWrapper.swift
@@ -17,6 +17,16 @@ public final class AirshipEmbeddedViewWrapper: UIView {
         self.viewModel.embeddedID = embeddedID
     }
 
+    @objc(setSelectionType:)
+    public func setSelectionType(_ selectionType: String?) {
+        self.viewModel.selectionType = selectionType
+    }
+
+    @objc(setSelectionInstanceId:)
+    public func setSelectionInstanceId(_ selectionInstanceId: String?) {
+        self.viewModel.selectionInstanceId = selectionInstanceId
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -87,7 +97,8 @@ struct ReactAirshipEmbeddedView: View {
                 embeddedSize: .init(
                     parentWidth: viewModel.width,
                     parentHeight: viewModel.height
-                )
+                ),
+                selection: viewModel.selection
             )
         }
     }
@@ -96,6 +107,15 @@ struct ReactAirshipEmbeddedView: View {
     class ViewModel: ObservableObject {
       @Published var embeddedID: String?
         @Published var size: CGSize?
+        @Published var selectionType: String?
+        @Published var selectionInstanceId: String?
+
+        var selection: AirshipEmbeddedSelection {
+            if selectionType == "instance_id", let selectionInstanceId {
+                return .instance(selectionInstanceId)
+            }
+            return .priority
+        }
 
         var height: CGFloat {
             guard let height = self.size?.height, height > 0 else {

--- a/ios/RNAirshipEmbeddedView.h
+++ b/ios/RNAirshipEmbeddedView.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 @property (nonatomic, copy) NSString *embeddedID;
+@property (nonatomic, copy) NSString *selectionType;
+@property (nonatomic, copy, nullable) NSString *selectionInstanceId;
 
 @end
 

--- a/ios/RNAirshipEmbeddedView.mm
+++ b/ios/RNAirshipEmbeddedView.mm
@@ -45,6 +45,8 @@ using namespace facebook::react;
 {
     const auto &newProps = *std::static_pointer_cast<const RNAirshipEmbeddedViewProps>(props);
     self.embeddedID = [NSString stringWithUTF8String:newProps.embeddedId.c_str()];
+    self.selectionType = [NSString stringWithUTF8String:toString(newProps.selectionType).c_str()];
+    self.selectionInstanceId = newProps.selectionInstanceId.empty() ? nil : [NSString stringWithUTF8String:newProps.selectionInstanceId.c_str()];
 
     [super updateProps:props oldProps:oldProps];
 }
@@ -77,6 +79,18 @@ using namespace facebook::react;
     _embeddedID = embeddedID;
     __weak RNAirshipEmbeddedView *weakSelf = self;
     [weakSelf.wrapper setEmbeddedID:embeddedID];
+}
+
+- (void)setSelectionType:(NSString *)selectionType {
+    _selectionType = selectionType;
+    __weak RNAirshipEmbeddedView *weakSelf = self;
+    [weakSelf.wrapper setSelectionType:selectionType];
+}
+
+- (void)setSelectionInstanceId:(nullable NSString *)selectionInstanceId {
+    _selectionInstanceId = selectionInstanceId;
+    __weak RNAirshipEmbeddedView *weakSelf = self;
+    [weakSelf.wrapper setSelectionInstanceId:selectionInstanceId];
 }
 
 

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
   
-  s.dependency "AirshipFrameworkProxy", "15.10.0"
+  s.dependency "AirshipFrameworkProxy", "15.11.0"
 end

--- a/src/AirshipEmbeddedView.tsx
+++ b/src/AirshipEmbeddedView.tsx
@@ -7,6 +7,14 @@ import RNAirshipEmbeddedView from './RNAirshipEmbeddedViewNativeComponent';
 import { ViewStyle } from 'react-native';
 
 /**
+ * Controls which pending embedded content instance is displayed when more
+ * than one is available for the same embedded ID.
+ */
+export type AirshipEmbeddedViewSelection =
+  | { type: 'priority' }
+  | { type: 'instance_id'; instanceId: string };
+
+/**
  * AirshipEmbeddedView props
  */
 export interface AirshipEmbeddedViewProp {
@@ -16,6 +24,12 @@ export interface AirshipEmbeddedViewProp {
    * The embedded Id.
    */
   embeddedId: string;
+
+  /**
+   * How to select which pending content to display when more than one is
+   * available. Defaults to priority ordering.
+   */
+  selection?: AirshipEmbeddedViewSelection;
 }
 
 /**
@@ -23,9 +37,14 @@ export interface AirshipEmbeddedViewProp {
  */
 export class AirshipEmbeddedView extends React.Component<AirshipEmbeddedViewProp> {
   render() {
+    const { selection, ...rest } = this.props;
     return (
       <RNAirshipEmbeddedView
-        {...this.props}
+        {...rest}
+        selectionType={selection?.type}
+        selectionInstanceId={
+          selection?.type === 'instance_id' ? selection.instanceId : undefined
+        }
       />
     );
   }

--- a/src/RNAirshipEmbeddedViewNativeComponent.ts
+++ b/src/RNAirshipEmbeddedViewNativeComponent.ts
@@ -1,8 +1,14 @@
 // @ts-ignore
 import { codegenNativeComponent, type HostComponent, type ViewProps } from 'react-native';
+import type {
+  WithDefault,
+  // @ts-ignore
+} from 'react-native/Libraries/Types/CodegenTypes';
 
 interface NativeProps extends ViewProps {
   embeddedId: string;
+  selectionType?: WithDefault<'priority' | 'instance_id', 'priority'>;
+  selectionInstanceId?: string;
 }
 
 export default codegenNativeComponent<NativeProps>('RNAirshipEmbeddedView') as HostComponent<NativeProps>;


### PR DESCRIPTION
### What do these changes do?
Adds an optional `selection` parameter to `AirshipEmbeddedView` to control which pending instance displays when more than one is available for an embedded ID: priority (current default) or a specific instance ID. Also bumps the framework proxy to 15.11.0 to pick up the iOS and Android SDK versions that added this.

### Why are these changes necessary?
Both native SDKs added a way to target a specific pending embedded content instance instead of relying on priority ordering, and this exposes that to React Native apps.

### How did you verify these changes?
Checked that the native parameter shapes generated on both platforms match what the bridge code reads, and ran typecheck against the diff (pre-existing unrelated errors on main are untouched). Added a demo card to the example app's Embedded Views screen exercising the new parameter.

#### Verification Screenshots: