### PR TITLE
Fix message center mark-as-read regression on iOS

### DIFF
--- a/ios/MessageWebViewWrapper.swift
+++ b/ios/MessageWebViewWrapper.swift
@@ -69,6 +69,7 @@ public final class MessageWebViewWrapper: UIView {
             case .loading:
                 break
             case .loaded:
+                Task { await self.state.viewModel?.markRead() }
                 self.delegate?.onLoadFinished(messageID: messageID)
             case .error(let error):
                 switch error {


### PR DESCRIPTION
## Summary

- The `MessageCenterMessageContentView` SDK (per its own docs) explicitly does **not** mark messages as read — that's the host's responsibility.
- The MOBILE-5735 refactor dropped the explicit `markMessageRead` call that the old `WKWebView`-based `webView(_:didFinish:)` handler had, so messages were never marked as read after loading on iOS.
- Fix: call `viewModel.markRead()` when the phase transitions to `.loaded` in `MessageWebViewWrapper`.
- Android was not affected — the new `onMessageLoaded` callback already calls `viewModel.markMessagesRead(message)`.

## Test plan

- [ ] Open a message center message on iOS and verify it transitions from unread to read after loading
- [ ] Verify unread badge count decrements after viewing a message
- [ ] Verify Android read-marking still works (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)