### PR TITLE
Release 26.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # React Native Module 26.0.0 Changelog
 
+## Version 26.9.0 - July 23, 2026
+
+Minor release that updates the Android SDK to 20.10.0 and the iOS SDK to 20.11.0.
+
+### Changes
+- Updated Android SDK to [20.10.0](https://github.com/urbanairship/android-library/releases/tag/20.10.0)
+- Updated iOS SDK to [20.11.0](https://github.com/urbanairship/ios-library/releases/tag/20.11.0)
+
+
 ## Version 26.8.0 - July 13, 2026
 
 Minor release that updates the Android SDK to 20.9.0 and the iOS SDK to 20.10.0; adds improved prioritization control for embedded displays, and fixes a bug causing messages to fail to render in the embedded message view.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Minor release that updates the Android SDK to 20.10.0 and the iOS SDK to 20.11.0
 - Updated iOS SDK to [20.11.0](https://github.com/urbanairship/ios-library/releases/tag/20.11.0)
 - Added `addPendingEmbeddedListener` to `AirshipInApp`
 - Fixed message center mark-as-read regression on iOS
-- Updated to React Native 0.86
 
 
 ## Version 26.8.0 - July 13, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Version 26.9.0 - July 23, 2026
 
-Minor release that updates the Android SDK to 20.10.0 and the iOS SDK to 20.11.0.
+Minor release that updates the Android SDK to 20.10.0 and the iOS SDK to 20.11.0, adds a pending embedded listener, and fixes a message center mark-as-read regression on iOS.
 
 ### Changes
 - Updated Android SDK to [20.10.0](https://github.com/urbanairship/android-library/releases/tag/20.10.0)
 - Updated iOS SDK to [20.11.0](https://github.com/urbanairship/ios-library/releases/tag/20.11.0)
+- Added `addPendingEmbeddedListener` to `AirshipInApp`
+- Fixed message center mark-as-read regression on iOS
+- Updated to React Native 0.86
 
 
 ## Version 26.8.0 - July 13, 2026

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=36
 Airship_compileSdkVersion=36
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=15.12.0
+Airship_airshipProxyVersion=15.13.0

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -36,7 +36,7 @@ public final class AirshipReactNative: NSObject, Sendable {
         AirshipProxy.shared
     }
 
-    public static let version: String = "26.8.0"
+    public static let version: String = "26.9.0"
 
     private let eventNotifier = EventNotifier()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "26.8.0",
+  "version": "26.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ua/react-native-airship",
-      "version": "26.8.0",
+      "version": "26.9.0",
       "license": "Apache-2.0",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "26.8.0",
+  "version": "26.9.0",
   "description": "Airship plugin for React Native apps.",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
   
-  s.dependency "AirshipFrameworkProxy", "15.12.0"
+  s.dependency "AirshipFrameworkProxy", "15.13.0"
 end


### PR DESCRIPTION
Automated release preparation for React Native v26.9.0

## Version Updates
- Plugin: 26.9.0
- Framework Proxy: 15.13.0
- iOS SDK: 20.11.0
- Android SDK: 20.10.0

## Validation Reminder
⚠️ **Note:** Since this release updates the underlying native SDKs, the changelog entries across all framework plugins will be similar. This is expected and correct.

## Changed Files
```
CHANGELOG.md
android/gradle.properties
ios/AirshipReactNative.swift
package-lock.json
package.json
react-native-airship.podspec
```

## Next Steps
1. Review version updates
2. Verify changelog accuracy
3. Merge when ready

---
🤖 Generated by centralized release automation